### PR TITLE
feat(agent): implement dynamic module registry and SSL bypass functionality

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1,225 +1,76 @@
 /// <reference types="npm:@types/frida-gum" />
 
-declare const Java: {
-  perform(fn: () => void): void;
-  use(className: string): any;
-  registerClass(spec: {
-    name: string;
-    implements: any[];
-    methods: Record<string, (...args: any[]) => any>;
-  }): any;
-};
+import type { HookRule } from "./types";
+import { getModule, listInterfaces } from "./router";
 
-const nopVerifyCallback = new NativeCallback(
-  (_ssl: NativePointer, _out_alert: NativePointer): number => 0,
-  "int",
-  ["pointer", "pointer"],
-);
+const appliedRules: HookRule[] = [];
 
-const nopCertVerifyCallback = new NativeCallback(
-  (_x509_ctx: NativePointer, _arg: NativePointer): number => 1,
-  "int",
-  ["pointer", "pointer"],
-);
-
-function hookNativeVerification(mod: Module): void {
-  const setVerify = mod.findExportByName("SSL_CTX_set_verify");
-  if (setVerify) {
-    Interceptor.attach(setVerify, {
-      onEnter(args) {
-        args[1] = ptr(0);
-        args[2] = ptr(0);
-      },
-    });
-  }
-
-  const setCustomVerify = mod.findExportByName("SSL_CTX_set_custom_verify");
-  if (setCustomVerify) {
-    Interceptor.attach(setCustomVerify, {
-      onEnter(args) {
-        args[1] = ptr(0);
-        args[2] = nopVerifyCallback;
-      },
-    });
-  }
-
-  const sslSetCustomVerify = mod.findExportByName("SSL_set_custom_verify");
-  if (sslSetCustomVerify) {
-    Interceptor.attach(sslSetCustomVerify, {
-      onEnter(args) {
-        args[1] = ptr(0);
-        args[2] = nopVerifyCallback;
-      },
-    });
-  }
-
-  const setCertVerifyCb = mod.findExportByName(
-    "SSL_CTX_set_cert_verify_callback",
+function rulesEqual(a: HookRule, b: HookRule): boolean {
+  return (
+    a.namespace === b.namespace &&
+    a.method === b.method &&
+    JSON.stringify(a.args) === JSON.stringify(b.args)
   );
-  if (setCertVerifyCb) {
-    Interceptor.attach(setCertVerifyCb, {
-      onEnter(args) {
-        args[1] = nopCertVerifyCallback;
-        args[2] = ptr(0);
-      },
-    });
+}
+
+function invoke(
+  namespace: string,
+  method: string,
+  args: unknown[],
+): unknown {
+  const mod = getModule(namespace);
+  if (!mod) throw new Error(`unknown namespace: ${namespace}`);
+
+  const fn = mod[method];
+  if (typeof fn !== "function")
+    throw new Error(`unknown method: ${namespace}.${method}`);
+
+  const result = fn(...args);
+
+  const rule: HookRule = { namespace, method, args, enabled: true };
+  if (!appliedRules.some((r) => rulesEqual(r, rule))) {
+    appliedRules.push(rule);
   }
 
-  const x509VerifyCert = mod.findExportByName("X509_verify_cert");
-  if (x509VerifyCert) {
-    Interceptor.replace(
-      x509VerifyCert,
-      new NativeCallback(
-        (_ctx: NativePointer): number => 1,
-        "int",
-        ["pointer"],
-      ),
-    );
+  return result;
+}
+
+function restore(rules: HookRule[]): void {
+  appliedRules.length = 0;
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    try {
+      invoke(rule.namespace, rule.method, rule.args);
+    } catch (e) {
+      console.error(
+        `restore failed for ${rule.namespace}.${rule.method}:`,
+        e,
+      );
+    }
   }
 }
 
-const SSL_LIB_PATTERN = /ssl|crypto|boring|flutter|cronet|conscrypt|curl/i;
-const hookedModules = new Set<string>();
-
-for (const mod of Process.enumerateModules()) {
-  if (!SSL_LIB_PATTERN.test(mod.name)) continue;
-  if (hookedModules.has(mod.path)) continue;
-  hookedModules.add(mod.path);
-  try {
-    hookNativeVerification(mod);
-  } catch (_) {}
+function snapshot(): HookRule[] {
+  return JSON.parse(JSON.stringify(appliedRules));
 }
-
-Process.attachModuleObserver({
-  onAdded(mod) {
-    if (!SSL_LIB_PATTERN.test(mod.name)) return;
-    if (hookedModules.has(mod.path)) return;
-    hookedModules.add(mod.path);
-    try {
-      hookNativeVerification(mod);
-    } catch (_) {}
-  },
-});
-
-Java.perform(() => {
-  try {
-    const CertificatePinner = Java.use("okhttp3.CertificatePinner");
-    CertificatePinner.check.overload(
-      "java.lang.String",
-      "java.util.List",
-    ).implementation = function () {};
-
-    try {
-      CertificatePinner["check$okhttp"].overload(
-        "java.lang.String",
-        "java.util.List",
-      ).implementation = function () {};
-    } catch (_) {}
-  } catch (_) {}
-
-  try {
-    const OkHostnameVerifier = Java.use(
-      "okhttp3.internal.tls.OkHostnameVerifier",
-    );
-    OkHostnameVerifier.verify.overload(
-      "java.lang.String",
-      "javax.net.ssl.SSLSession",
-    ).implementation = function (): boolean {
-      return true;
-    };
-  } catch (_) {}
-
-  try {
-    const X509TrustManager = Java.use("javax.net.ssl.X509TrustManager");
-    const SSLContext = Java.use("javax.net.ssl.SSLContext");
-
-    const TrustAll = Java.registerClass({
-      name: "com.juicebox.TrustAll",
-      implements: [X509TrustManager],
-      methods: {
-        checkClientTrusted() {},
-        checkServerTrusted() {},
-        getAcceptedIssuers() {
-          return [];
-        },
-      },
-    });
-    const trustAll = TrustAll.$new();
-
-    SSLContext.init.implementation = function (
-      km: any,
-      _tm: any,
-      sr: any,
-    ) {
-      this.init(km, [trustAll], sr);
-    };
-  } catch (_) {}
-
-  try {
-    const TrustManagerImpl = Java.use(
-      "com.android.org.conscrypt.TrustManagerImpl",
-    );
-
-    TrustManagerImpl.verifyChain.overload(
-      "[Ljava.security.cert.X509Certificate;",
-      "[[B",
-      "[B",
-      "java.lang.String",
-      "java.lang.String",
-      "boolean",
-    ).implementation = function (
-      untrustedChain: any,
-      _ocspResponses: any,
-      _tlsSctData: any,
-      _authType: any,
-      _host: any,
-      _clientAuth: any,
-    ): any {
-      return Java.use("java.util.Arrays").asList(untrustedChain);
-    };
-  } catch (_) {}
-
-  try {
-    const TrustManagerImpl = Java.use(
-      "com.android.org.conscrypt.TrustManagerImpl",
-    );
-
-    TrustManagerImpl.checkServerTrusted.overload(
-      "[Ljava.security.cert.X509Certificate;",
-      "java.lang.String",
-    ).implementation = function () {};
-
-    try {
-      TrustManagerImpl.checkServerTrusted.overload(
-        "[Ljava.security.cert.X509Certificate;",
-        "java.lang.String",
-        "java.lang.String",
-      ).implementation = function () {
-        return Java.use("java.util.ArrayList").$new();
-      };
-    } catch (_) {}
-  } catch (_) {}
-
-  try {
-    const ClassLoader = Java.use("java.lang.ClassLoader");
-    ClassLoader.loadClass.overload("java.lang.String").implementation =
-      function (name: string): any {
-        const klass = this.loadClass(name);
-        if (name === "okhttp3.CertificatePinner") {
-          try {
-            const CP = Java.use("okhttp3.CertificatePinner");
-            CP.check.overload(
-              "java.lang.String",
-              "java.util.List",
-            ).implementation = function () {};
-          } catch (_) {}
-        }
-        return klass;
-      };
-  } catch (_) {}
-});
 
 rpc.exports = {
+  invoke(namespace: string, method: string, args: unknown[]): unknown {
+    return invoke(namespace, method, args);
+  },
+
+  interfaces(): Record<string, string[]> {
+    return listInterfaces();
+  },
+
+  restore(rules: HookRule[]): void {
+    restore(rules);
+  },
+
+  snapshot(): HookRule[] {
+    return snapshot();
+  },
+
   ping(): string {
     return "pong";
   },

--- a/agent/src/modules/ssl.ts
+++ b/agent/src/modules/ssl.ts
@@ -1,0 +1,295 @@
+/// <reference types="npm:@types/frida-gum" />
+
+import type { AgentModule } from "../types";
+
+declare const Java: {
+  perform(fn: () => void): void;
+  use(className: string): any;
+  registerClass(spec: {
+    name: string;
+    implements: any[];
+    methods: Record<string, (...args: any[]) => any>;
+  }): any;
+};
+
+const nopVerifyCallback = new NativeCallback(
+  (_ssl: NativePointer, _out_alert: NativePointer): number => 0,
+  "int",
+  ["pointer", "pointer"],
+);
+
+const nopCertVerifyCallback = new NativeCallback(
+  (_x509_ctx: NativePointer, _arg: NativePointer): number => 1,
+  "int",
+  ["pointer", "pointer"],
+);
+
+const SSL_LIB_PATTERN = /ssl|crypto|boring|flutter|cronet|conscrypt|curl/i;
+const hookedModules = new Set<string>();
+
+let _nativeApplied = false;
+let _javaApplied = false;
+
+function hookNativeVerification(mod: Module): void {
+  const setVerify = mod.findExportByName("SSL_CTX_set_verify");
+  if (setVerify) {
+    Interceptor.attach(setVerify, {
+      onEnter(args) {
+        args[1] = ptr(0);
+        args[2] = ptr(0);
+      },
+    });
+  }
+
+  const setCustomVerify = mod.findExportByName("SSL_CTX_set_custom_verify");
+  if (setCustomVerify) {
+    Interceptor.attach(setCustomVerify, {
+      onEnter(args) {
+        args[1] = ptr(0);
+        args[2] = nopVerifyCallback;
+      },
+    });
+  }
+
+  const sslSetCustomVerify = mod.findExportByName("SSL_set_custom_verify");
+  if (sslSetCustomVerify) {
+    Interceptor.attach(sslSetCustomVerify, {
+      onEnter(args) {
+        args[1] = ptr(0);
+        args[2] = nopVerifyCallback;
+      },
+    });
+  }
+
+  const setCertVerifyCb = mod.findExportByName(
+    "SSL_CTX_set_cert_verify_callback",
+  );
+  if (setCertVerifyCb) {
+    Interceptor.attach(setCertVerifyCb, {
+      onEnter(args) {
+        args[1] = nopCertVerifyCallback;
+        args[2] = ptr(0);
+      },
+    });
+  }
+
+  const x509VerifyCert = mod.findExportByName("X509_verify_cert");
+  if (x509VerifyCert) {
+    Interceptor.replace(
+      x509VerifyCert,
+      new NativeCallback(
+        (_ctx: NativePointer): number => 1,
+        "int",
+        ["pointer"],
+      ),
+    );
+  }
+}
+
+interface BypassNativeResult {
+  alreadyApplied: boolean;
+  hookedCount: number;
+}
+
+function bypassNative(): BypassNativeResult {
+  if (_nativeApplied) return { alreadyApplied: true, hookedCount: hookedModules.size };
+
+  for (const mod of Process.enumerateModules()) {
+    if (!SSL_LIB_PATTERN.test(mod.name)) continue;
+    if (hookedModules.has(mod.path)) continue;
+    hookedModules.add(mod.path);
+    try {
+      hookNativeVerification(mod);
+    } catch (_) {}
+  }
+
+  Process.attachModuleObserver({
+    onAdded(mod) {
+      if (!SSL_LIB_PATTERN.test(mod.name)) return;
+      if (hookedModules.has(mod.path)) return;
+      hookedModules.add(mod.path);
+      try {
+        hookNativeVerification(mod);
+      } catch (_) {}
+    },
+  });
+
+  _nativeApplied = true;
+  return { alreadyApplied: false, hookedCount: hookedModules.size };
+}
+
+interface JavaHookResult {
+  ok: boolean;
+  error?: string;
+}
+
+interface BypassJavaResult {
+  alreadyApplied: boolean;
+  certificatePinner?: JavaHookResult;
+  okHostnameVerifier?: JavaHookResult;
+  trustManager?: JavaHookResult;
+  conscrypt?: JavaHookResult;
+  classLoader?: JavaHookResult;
+}
+
+function bypassJava(): BypassJavaResult {
+  if (_javaApplied) return { alreadyApplied: true };
+
+  const results: BypassJavaResult = { alreadyApplied: false };
+
+  Java.perform(() => {
+    try {
+      const CertificatePinner = Java.use("okhttp3.CertificatePinner");
+      CertificatePinner.check.overload(
+        "java.lang.String",
+        "java.util.List",
+      ).implementation = function () {};
+
+      try {
+        CertificatePinner["check$okhttp"].overload(
+          "java.lang.String",
+          "java.util.List",
+        ).implementation = function () {};
+      } catch (_) {}
+
+      results.certificatePinner = { ok: true };
+    } catch (e) {
+      results.certificatePinner = { ok: false, error: String(e) };
+    }
+
+    try {
+      const OkHostnameVerifier = Java.use(
+        "okhttp3.internal.tls.OkHostnameVerifier",
+      );
+      OkHostnameVerifier.verify.overload(
+        "java.lang.String",
+        "javax.net.ssl.SSLSession",
+      ).implementation = function (): boolean {
+        return true;
+      };
+
+      results.okHostnameVerifier = { ok: true };
+    } catch (e) {
+      results.okHostnameVerifier = { ok: false, error: String(e) };
+    }
+
+    try {
+      const X509TrustManager = Java.use("javax.net.ssl.X509TrustManager");
+      const SSLContext = Java.use("javax.net.ssl.SSLContext");
+
+      const TrustAll = Java.registerClass({
+        name: "com.juicebox.TrustAll",
+        implements: [X509TrustManager],
+        methods: {
+          checkClientTrusted() {},
+          checkServerTrusted() {},
+          getAcceptedIssuers() {
+            return [];
+          },
+        },
+      });
+      const trustAll = TrustAll.$new();
+
+      SSLContext.init.implementation = function (
+        km: any,
+        _tm: any,
+        sr: any,
+      ) {
+        this.init(km, [trustAll], sr);
+      };
+
+      results.trustManager = { ok: true };
+    } catch (e) {
+      results.trustManager = { ok: false, error: String(e) };
+    }
+
+    try {
+      const TrustManagerImpl = Java.use(
+        "com.android.org.conscrypt.TrustManagerImpl",
+      );
+
+      TrustManagerImpl.verifyChain.overload(
+        "[Ljava.security.cert.X509Certificate;",
+        "[[B",
+        "[B",
+        "java.lang.String",
+        "java.lang.String",
+        "boolean",
+      ).implementation = function (
+        untrustedChain: any,
+        _ocspResponses: any,
+        _tlsSctData: any,
+        _authType: any,
+        _host: any,
+        _clientAuth: any,
+      ): any {
+        return Java.use("java.util.Arrays").asList(untrustedChain);
+      };
+
+      results.conscrypt = { ok: true };
+    } catch (e) {
+      results.conscrypt = { ok: false, error: String(e) };
+    }
+
+    try {
+      const TrustManagerImpl = Java.use(
+        "com.android.org.conscrypt.TrustManagerImpl",
+      );
+
+      TrustManagerImpl.checkServerTrusted.overload(
+        "[Ljava.security.cert.X509Certificate;",
+        "java.lang.String",
+      ).implementation = function () {};
+
+      try {
+        TrustManagerImpl.checkServerTrusted.overload(
+          "[Ljava.security.cert.X509Certificate;",
+          "java.lang.String",
+          "java.lang.String",
+        ).implementation = function () {
+          return Java.use("java.util.ArrayList").$new();
+        };
+      } catch (_) {}
+    } catch (_) {}
+
+    try {
+      const ClassLoader = Java.use("java.lang.ClassLoader");
+      ClassLoader.loadClass.overload("java.lang.String").implementation =
+        function (name: string): any {
+          const klass = this.loadClass(name);
+          if (name === "okhttp3.CertificatePinner") {
+            try {
+              const CP = Java.use("okhttp3.CertificatePinner");
+              CP.check.overload(
+                "java.lang.String",
+                "java.util.List",
+              ).implementation = function () {};
+            } catch (_) {}
+          }
+          return klass;
+        };
+
+      results.classLoader = { ok: true };
+    } catch (e) {
+      results.classLoader = { ok: false, error: String(e) };
+    }
+  });
+
+  _javaApplied = true;
+  return results;
+}
+
+interface BypassResult {
+  native: BypassNativeResult;
+  java: BypassJavaResult;
+}
+
+function bypass(): BypassResult {
+  return {
+    native: bypassNative(),
+    java: bypassJava(),
+  };
+}
+
+const ssl: AgentModule = { bypass, bypassNative, bypassJava };
+export default ssl;

--- a/agent/src/router.ts
+++ b/agent/src/router.ts
@@ -1,0 +1,16 @@
+import type { AgentModule } from "./types";
+import ssl from "./modules/ssl";
+
+const registry: Record<string, AgentModule> = { ssl };
+
+export function getModule(namespace: string): AgentModule | undefined {
+  return registry[namespace];
+}
+
+export function listInterfaces(): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+  for (const [ns, mod] of Object.entries(registry)) {
+    result[ns] = Object.keys(mod).filter((k) => typeof mod[k] === "function");
+  }
+  return result;
+}

--- a/agent/src/types.ts
+++ b/agent/src/types.ts
@@ -1,0 +1,12 @@
+export type ModuleFn = (...args: unknown[]) => unknown;
+
+export interface AgentModule {
+  [method: string]: ModuleFn;
+}
+
+export interface HookRule {
+  namespace: string;
+  method: string;
+  args: unknown[];
+  enabled: boolean;
+}

--- a/internal/bridge/client.go
+++ b/internal/bridge/client.go
@@ -179,6 +179,29 @@ func (c *Client) Detach(sessionId string) error {
 	return err
 }
 
+func (c *Client) AgentInvoke(sessionId, namespace, method string, args []any) (json.RawMessage, error) {
+	return c.call("agentInvoke", map[string]any{
+		"sessionId": sessionId,
+		"namespace": namespace,
+		"method":    method,
+		"args":      args,
+	})
+}
+
+func (c *Client) AgentInterfaces(sessionId string) (map[string][]string, error) {
+	raw, err := c.call("agentInterfaces", map[string]string{"sessionId": sessionId})
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string][]string
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("bridge.AgentInterfaces: %w", err)
+	}
+
+	return result, nil
+}
+
 type SubscribeConn struct {
 	Reader *bufio.Reader
 	conn   net.Conn

--- a/sidecar/bridge.ts
+++ b/sidecar/bridge.ts
@@ -219,6 +219,13 @@ async function handleAttach(
   });
 
   await script.load();
+
+  try {
+    await script.exports.invoke("ssl", "bypass", []);
+  } catch (err) {
+    console.error(`[${sessionId}] ssl bypass failed:`, err);
+  }
+
   await device.resume(pid);
   console.log(`attached to ${identifier} (pid ${pid}), session ${sessionId}`);
 
@@ -344,6 +351,49 @@ async function handleRequest(req: JsonRpcRequest): Promise<JsonRpcResponse> {
 
       case "detach":
         return await handleDetach(req);
+
+      case "agentInvoke": {
+        const sessionId = req.params?.sessionId as string;
+        const namespace = req.params?.namespace as string;
+        const method = req.params?.method as string;
+        const args = (req.params?.args as unknown[]) ?? [];
+        if (!sessionId) return fail(req.id, -32602, "missing param: sessionId");
+        if (!namespace) return fail(req.id, -32602, "missing param: namespace");
+        if (!method) return fail(req.id, -32602, "missing param: method");
+        const state = sessions.get(sessionId);
+        if (!state) return fail(req.id, -32602, "session not found");
+        const result = await state.script.exports.invoke(namespace, method, args);
+        return ok(req.id, result);
+      }
+
+      case "agentInterfaces": {
+        const sessionId = req.params?.sessionId as string;
+        if (!sessionId) return fail(req.id, -32602, "missing param: sessionId");
+        const state = sessions.get(sessionId);
+        if (!state) return fail(req.id, -32602, "session not found");
+        const result = await state.script.exports.interfaces();
+        return ok(req.id, result);
+      }
+
+      case "agentSnapshot": {
+        const sessionId = req.params?.sessionId as string;
+        if (!sessionId) return fail(req.id, -32602, "missing param: sessionId");
+        const state = sessions.get(sessionId);
+        if (!state) return fail(req.id, -32602, "session not found");
+        const result = await state.script.exports.snapshot();
+        return ok(req.id, result);
+      }
+
+      case "agentRestore": {
+        const sessionId = req.params?.sessionId as string;
+        const rules = req.params?.rules as unknown[];
+        if (!sessionId) return fail(req.id, -32602, "missing param: sessionId");
+        if (!rules) return fail(req.id, -32602, "missing param: rules");
+        const state = sessions.get(sessionId);
+        if (!state) return fail(req.id, -32602, "session not found");
+        await state.script.exports.restore(rules);
+        return ok(req.id, { success: true });
+      }
 
       default:
         return fail(req.id, -32601, `unknown method: ${req.method}`);


### PR DESCRIPTION
This pull request introduces a modular agent architecture for native and Java SSL bypass functionality, enabling dynamic invocation and introspection of agent modules via a new router and interface system. The changes refactor the previous monolithic SSL bypass logic into a dedicated `ssl` module, establish a registry for agent modules, and add new bridge endpoints for invoking agent methods, listing interfaces, and managing hook rules. This improves maintainability, extensibility, and provides a foundation for future agent modules.

closes #18 