### PR TITLE
feat(classes): add Java class inspection features including listing, detail retrieval, method invocation, and field reading

### DIFF
--- a/agent/deno.json
+++ b/agent/deno.json
@@ -1,7 +1,8 @@
 {
   "nodeModulesDir": "auto",
   "imports": {
-    "frida-compile": "npm:frida-compile@^19.0.4"
+    "frida-compile": "npm:frida-compile@^19.0.4",
+    "frida-java-bridge": "npm:frida-java-bridge@^7.0.12"
   },
   "tasks": {
     "build": "node_modules/.bin/frida-compile src/index.ts -o dist/agent.js",

--- a/agent/deno.lock
+++ b/agent/deno.lock
@@ -2,7 +2,8 @@
   "version": "5",
   "specifiers": {
     "npm:frida-compile@19.0.4": "19.0.4",
-    "npm:frida-compile@^19.0.4": "19.0.4"
+    "npm:frida-compile@^19.0.4": "19.0.4",
+    "npm:frida-java-bridge@^7.0.12": "7.0.12"
   },
   "npm": {
     "balanced-match@4.0.3": {
@@ -79,6 +80,9 @@
         "frida"
       ],
       "bin": true
+    },
+    "frida-java-bridge@7.0.12": {
+      "integrity": "sha512-xpoTFPQkUjNMeRnyZ6rUj/APlYGWpKEv5iekOk4lQeDcv9fv8J/s3ETjTRdSfyZ8/aPv9r8+oBmsxN2gCHRTqg=="
     },
     "frida@17.7.3": {
       "integrity": "sha512-hldU+VsipYecq3JzQqz6+Qaa4PE3VdOcUvf14pn/zAKxN/Ds/sptSbEGVea4Fx+oFiTgYOEsFf+4zcvb8qctjA==",
@@ -239,7 +243,8 @@
   },
   "workspace": {
     "dependencies": [
-      "npm:frida-compile@^19.0.4"
+      "npm:frida-compile@^19.0.4",
+      "npm:frida-java-bridge@^7.0.12"
     ]
   }
 }

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -55,8 +55,8 @@ function snapshot(): HookRule[] {
 }
 
 rpc.exports = {
-  invoke(namespace: string, method: string, args: unknown[]): unknown {
-    return invoke(namespace, method, args);
+  async invoke(namespace: string, method: string, args: unknown[]): Promise<unknown> {
+    return await invoke(namespace, method, args);
   },
 
   interfaces(): Record<string, string[]> {

--- a/agent/src/modules/classes.ts
+++ b/agent/src/modules/classes.ts
@@ -1,0 +1,192 @@
+/// <reference types="npm:@types/frida-gum" />
+
+import type { AgentModule } from "../types";
+import Java from "frida-java-bridge";
+
+const MAX_RESULTS = 500;
+
+function withJava<T>(fallback: T, fn: (resolve: (v: T) => void) => void): Promise<T> {
+  if (!Java.available) return Promise.resolve(fallback);
+  return new Promise<T>((resolve) => {
+    Java.perform(() => {
+      fn(resolve);
+    });
+  });
+}
+
+function list(query: unknown): Promise<string[]> {
+  return withJava([] as string[], (resolve) => {
+    const q = String(query ?? "").toLowerCase();
+    const all = Java.enumerateLoadedClassesSync();
+    const filtered = q
+      ? all.filter((c) => c.toLowerCase().includes(q))
+      : all;
+    filtered.sort();
+    resolve(filtered.slice(0, MAX_RESULTS));
+  });
+}
+
+interface MethodInfo {
+  name: string;
+  parameterTypes: string[];
+  returnType: string;
+  modifiers: number;
+}
+
+interface FieldInfo {
+  name: string;
+  type: string;
+  modifiers: number;
+  value: unknown;
+}
+
+interface ClassDetail {
+  className: string;
+  methods: MethodInfo[];
+  fields: FieldInfo[];
+  interfaces: string[];
+  superclasses: string[];
+}
+
+function detail(className: unknown): Promise<ClassDetail> {
+  const cls = String(className);
+  const empty: ClassDetail = {
+    className: cls,
+    methods: [],
+    fields: [],
+    interfaces: [],
+    superclasses: [],
+  };
+
+  return withJava(empty, (resolve) => {
+    const result: ClassDetail = {
+      className: cls,
+      methods: [],
+      fields: [],
+      interfaces: [],
+      superclasses: [],
+    };
+
+    const wrapper = Java.use(cls);
+    const jclass = wrapper.class;
+
+    const methods = jclass.getDeclaredMethods();
+    for (let i = 0; i < methods.length; i++) {
+      const m = methods[i];
+      const params = m.getParameterTypes();
+      const paramTypes: string[] = [];
+      for (let j = 0; j < params.length; j++) {
+        paramTypes.push(params[j].getName());
+      }
+      result.methods.push({
+        name: m.getName(),
+        parameterTypes: paramTypes,
+        returnType: m.getReturnType().getName(),
+        modifiers: m.getModifiers(),
+      });
+    }
+
+    const fields = jclass.getDeclaredFields();
+    for (let i = 0; i < fields.length; i++) {
+      const f = fields[i];
+      const mods: number = f.getModifiers();
+      let value: unknown = null;
+      const isStatic = (mods & 0x0008) !== 0;
+      if (isStatic) {
+        try {
+          f.setAccessible(true);
+          const raw = f.get(null);
+          if (raw !== null && raw !== undefined) {
+            value = String(raw);
+          }
+        } catch (_) {
+          // non-readable field
+        }
+      }
+      result.fields.push({
+        name: f.getName(),
+        type: f.getType().getName(),
+        modifiers: mods,
+        value,
+      });
+    }
+
+    const ifaces = jclass.getInterfaces();
+    for (let i = 0; i < ifaces.length; i++) {
+      result.interfaces.push(ifaces[i].getName());
+    }
+
+    let sup = jclass.getSuperclass();
+    while (sup !== null) {
+      const name = sup.getName();
+      result.superclasses.push(name);
+      if (name === "java.lang.Object") break;
+      sup = sup.getSuperclass();
+    }
+
+    resolve(result);
+  });
+}
+
+function invokeMethod(
+  className: unknown,
+  methodName: unknown,
+  args: unknown,
+): Promise<unknown> {
+  return withJava<unknown>({ error: "Java not available" }, (resolve) => {
+    const cn = String(className);
+    const mn = String(methodName);
+    const a: string[] = Array.isArray(args) ? (args as string[]) : [];
+
+    const wrapper = Java.use(cn);
+    const jclass = wrapper.class;
+    const jmethod = jclass.getDeclaredMethods().find(
+      (m: any) => m.getName() === mn,
+    );
+    if (!jmethod) {
+      resolve({ error: `method ${mn} not found on ${cn}` });
+      return;
+    }
+
+    const isStatic = (jmethod.getModifiers() & 0x0008) !== 0;
+    if (!isStatic) {
+      resolve({ error: `${mn} is an instance method — invoke requires a live object reference` });
+      return;
+    }
+
+    try {
+      const method = wrapper[mn];
+      if (!method) {
+        resolve({ error: `method ${mn} not accessible on ${cn}` });
+        return;
+      }
+      const ret = a.length === 0 ? method.call(wrapper) : method.call(wrapper, ...a);
+      resolve({ value: ret !== null && ret !== undefined ? String(ret) : null });
+    } catch (e: any) {
+      resolve({ error: String(e.message ?? e) });
+    }
+  });
+}
+
+function readField(className: unknown, fieldName: unknown): Promise<unknown> {
+  return withJava<unknown>({ error: "Java not available" }, (resolve) => {
+    const cn = String(className);
+    const fn = String(fieldName);
+
+    try {
+      const wrapper = Java.use(cn);
+      const jclass = wrapper.class;
+      const f = jclass.getDeclaredField(fn);
+      f.setAccessible(true);
+      const raw = f.get(null);
+      resolve({
+        value: raw !== null && raw !== undefined ? String(raw) : null,
+      });
+    } catch (e: any) {
+      resolve({ error: String(e.message ?? e) });
+    }
+  });
+}
+
+const classes: AgentModule = { list, detail, invokeMethod, readField };
+export default classes;

--- a/agent/src/modules/ssl.ts
+++ b/agent/src/modules/ssl.ts
@@ -1,17 +1,7 @@
 /// <reference types="npm:@types/frida-gum" />
 
 import type { AgentModule } from "../types";
-
-declare const Java: {
-  available: boolean;
-  perform(fn: () => void): void;
-  use(className: string): any;
-  registerClass(spec: {
-    name: string;
-    implements: any[];
-    methods: Record<string, (...args: any[]) => any>;
-  }): any;
-};
+import Java from "frida-java-bridge";
 
 const nopVerifyCallback = new NativeCallback(
   (_ssl: NativePointer, _out_alert: NativePointer): number => 0,
@@ -133,16 +123,16 @@ interface BypassJavaResult {
   classLoader?: JavaHookResult;
 }
 
-function bypassJava(): BypassJavaResult {
+function bypassJava(): BypassJavaResult | Promise<BypassJavaResult> {
   if (_javaApplied) return { alreadyApplied: true };
 
-  if (typeof Java === "undefined" || !Java.available) {
+  if (!Java.available) {
     return { alreadyApplied: false };
   }
 
-  const results: BypassJavaResult = { alreadyApplied: false };
-
-  Java.perform(() => {
+  return new Promise<BypassJavaResult>((resolve) => {
+    Java.perform(() => {
+      const results: BypassJavaResult = { alreadyApplied: false };
     try {
       const CertificatePinner = Java.use("okhttp3.CertificatePinner");
       CertificatePinner.check.overload(
@@ -278,15 +268,16 @@ function bypassJava(): BypassJavaResult {
     } catch (e) {
       results.classLoader = { ok: false, error: String(e) };
     }
-  });
 
-  _javaApplied = true;
-  return results;
+      _javaApplied = true;
+      resolve(results);
+    });
+  });
 }
 
 interface BypassResult {
   native: BypassNativeResult;
-  java: BypassJavaResult;
+  java: BypassJavaResult | Promise<BypassJavaResult>;
 }
 
 function bypass(): BypassResult {

--- a/agent/src/router.ts
+++ b/agent/src/router.ts
@@ -1,7 +1,8 @@
 import type { AgentModule } from "./types";
 import ssl from "./modules/ssl";
+import classes from "./modules/classes";
 
-const registry: Record<string, AgentModule> = { ssl };
+const registry: Record<string, AgentModule> = { ssl, classes };
 
 export function getModule(namespace: string): AgentModule | undefined {
   return registry[namespace];

--- a/agent/src/types.ts
+++ b/agent/src/types.ts
@@ -1,4 +1,4 @@
-export type ModuleFn = (...args: unknown[]) => unknown;
+export type ModuleFn = (...args: unknown[]) => unknown | Promise<unknown>;
 
 export interface AgentModule {
   [method: string]: ModuleFn;

--- a/internal/features/sessions/chat/handler.go
+++ b/internal/features/sessions/chat/handler.go
@@ -130,9 +130,14 @@ func (h *Handler) Handle(c *router.Context) {
 		chattools.NewDropRequest(h.manager, sessionID),
 	}
 	for _, cap := range setup.Capabilities() {
-		if cap == "logstream" {
+		switch cap {
+		case "logstream":
 			sessionTools = append(sessionTools, chattools.NewRunLogcatQuery(h.db, sessionID))
-			break
+		case "frida":
+			sessionTools = append(sessionTools,
+				chattools.NewListClasses(h.manager, sessionID),
+				chattools.NewGetClassDetail(h.manager, sessionID),
+			)
 		}
 	}
 	sessionTools = append(sessionTools,

--- a/internal/features/sessions/chat/tools/get_class_detail.go
+++ b/internal/features/sessions/chat/tools/get_class_detail.go
@@ -1,0 +1,51 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/joakimcarlsson/ai/agent"
+	"github.com/joakimcarlsson/ai/tool"
+	"github.com/joakimcarlsson/juicebox/internal/session"
+)
+
+type GetClassDetailParams struct {
+	ClassName string `json:"className" description:"Fully qualified Java class name (e.g. 'com.example.auth.TokenManager')"`
+}
+
+type GetClassDetailTool struct {
+	manager   *session.Manager
+	sessionID string
+}
+
+func NewGetClassDetail(manager *session.Manager, sessionID string) *GetClassDetailTool {
+	return &GetClassDetailTool{manager: manager, sessionID: sessionID}
+}
+
+func (t *GetClassDetailTool) Info() tool.ToolInfo {
+	return tool.NewToolInfo(
+		"get_class_detail",
+		"Inspect a Java class at runtime. Returns declared methods (name, params, return type, modifiers), fields (name, type, modifiers, static values), implemented interfaces, and superclass chain.",
+		GetClassDetailParams{},
+	)
+}
+
+func (t *GetClassDetailTool) Run(ctx context.Context, params tool.ToolCall) (tool.ToolResponse, error) {
+	input, err := agent.ParseToolInput[GetClassDetailParams](params.Input)
+	if err != nil {
+		return tool.NewTextErrorResponse(fmt.Sprintf("invalid input: %v", err)), nil
+	}
+
+	if input.ClassName == "" {
+		return tool.NewTextErrorResponse("className is required"), nil
+	}
+
+	raw, err := t.manager.AgentInvoke(t.sessionID, "classes", "detail", []any{input.ClassName})
+	if err != nil {
+		return tool.NewTextErrorResponse(fmt.Sprintf("failed to get class detail: %v", err)), nil
+	}
+
+	var detail json.RawMessage = raw
+	return tool.NewJSONResponse(detail), nil
+}

--- a/internal/features/sessions/chat/tools/list_classes.go
+++ b/internal/features/sessions/chat/tools/list_classes.go
@@ -1,0 +1,55 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/joakimcarlsson/ai/agent"
+	"github.com/joakimcarlsson/ai/tool"
+	"github.com/joakimcarlsson/juicebox/internal/session"
+)
+
+type ListClassesParams struct {
+	Query string `json:"query" description:"Substring to filter class names by (e.g. 'auth', 'com.example'). Empty returns all."`
+}
+
+type ListClassesTool struct {
+	manager   *session.Manager
+	sessionID string
+}
+
+func NewListClasses(manager *session.Manager, sessionID string) *ListClassesTool {
+	return &ListClassesTool{manager: manager, sessionID: sessionID}
+}
+
+func (t *ListClassesTool) Info() tool.ToolInfo {
+	return tool.NewToolInfo(
+		"list_classes",
+		"Search loaded Java classes in the running app. Returns fully qualified class names matching the query substring. Useful for finding classes related to authentication, networking, crypto, etc.",
+		ListClassesParams{},
+	)
+}
+
+func (t *ListClassesTool) Run(ctx context.Context, params tool.ToolCall) (tool.ToolResponse, error) {
+	input, err := agent.ParseToolInput[ListClassesParams](params.Input)
+	if err != nil {
+		return tool.NewTextErrorResponse(fmt.Sprintf("invalid input: %v", err)), nil
+	}
+
+	raw, err := t.manager.AgentInvoke(t.sessionID, "classes", "list", []any{input.Query})
+	if err != nil {
+		return tool.NewTextErrorResponse(fmt.Sprintf("failed to list classes: %v", err)), nil
+	}
+
+	var classes []string
+	if err := json.Unmarshal(raw, &classes); err != nil {
+		return tool.NewTextErrorResponse("failed to parse class list"), nil
+	}
+
+	if len(classes) == 0 {
+		return tool.NewTextResponse(fmt.Sprintf("No loaded classes matching %q found.", input.Query)), nil
+	}
+
+	return tool.NewJSONResponse(classes), nil
+}

--- a/internal/features/sessions/classes/handler.go
+++ b/internal/features/sessions/classes/handler.go
@@ -1,0 +1,166 @@
+package classes
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/joakimcarlsson/go-router/router"
+	"github.com/joakimcarlsson/juicebox/internal/session"
+)
+
+type Handler struct {
+	manager *session.Manager
+}
+
+func NewHandler(manager *session.Manager) *Handler {
+	return &Handler{manager: manager}
+}
+
+type listResponse struct {
+	Classes []string `json:"classes"`
+	Total   int      `json:"total"`
+}
+
+func (h *Handler) List(c *router.Context) {
+	sessionID := c.Param("sessionId")
+	query := c.QueryDefault("query", "")
+	limit := c.QueryIntDefault("limit", 100)
+	offset := c.QueryIntDefault("offset", 0)
+
+	sess := h.manager.GetSession(sessionID)
+	if sess == nil {
+		c.JSON(http.StatusNotFound, map[string]string{"error": "session not found"})
+		return
+	}
+
+	raw, err := h.manager.AgentInvoke(sessionID, "classes", "list", []any{query})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	var all []string
+	if err := json.Unmarshal(raw, &all); err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to parse class list"})
+		return
+	}
+
+	total := len(all)
+	if offset > total {
+		offset = total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+
+	c.JSON(http.StatusOK, listResponse{
+		Classes: all[offset:end],
+		Total:   total,
+	})
+}
+
+func (h *Handler) Detail(c *router.Context) {
+	sessionID := c.Param("sessionId")
+	className := c.QueryDefault("className", "")
+
+	if className == "" {
+		c.JSON(http.StatusBadRequest, map[string]string{"error": "className is required"})
+		return
+	}
+
+	sess := h.manager.GetSession(sessionID)
+	if sess == nil {
+		c.JSON(http.StatusNotFound, map[string]string{"error": "session not found"})
+		return
+	}
+
+	raw, err := h.manager.AgentInvoke(sessionID, "classes", "detail", []any{className})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	var result json.RawMessage = raw
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(http.StatusOK)
+	c.Writer.Write(result) //nolint:errcheck
+}
+
+type invokeRequest struct {
+	ClassName  string   `json:"className"`
+	MethodName string   `json:"methodName"`
+	Args       []string `json:"args"`
+}
+
+func (h *Handler) Invoke(c *router.Context) {
+	sessionID := c.Param("sessionId")
+
+	sess := h.manager.GetSession(sessionID)
+	if sess == nil {
+		c.JSON(http.StatusNotFound, map[string]string{"error": "session not found"})
+		return
+	}
+
+	var req invokeRequest
+	if err := json.NewDecoder(c.Request.Body).Decode(&req); err != nil {
+		c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	if req.ClassName == "" || req.MethodName == "" {
+		c.JSON(http.StatusBadRequest, map[string]string{"error": "className and methodName are required"})
+		return
+	}
+
+	args := req.Args
+	if args == nil {
+		args = []string{}
+	}
+
+	raw, err := h.manager.AgentInvoke(sessionID, "classes", "invokeMethod", []any{req.ClassName, req.MethodName, args})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(http.StatusOK)
+	c.Writer.Write(raw) //nolint:errcheck
+}
+
+type readFieldRequest struct {
+	ClassName string `json:"className"`
+	FieldName string `json:"fieldName"`
+}
+
+func (h *Handler) ReadField(c *router.Context) {
+	sessionID := c.Param("sessionId")
+
+	sess := h.manager.GetSession(sessionID)
+	if sess == nil {
+		c.JSON(http.StatusNotFound, map[string]string{"error": "session not found"})
+		return
+	}
+
+	var req readFieldRequest
+	if err := json.NewDecoder(c.Request.Body).Decode(&req); err != nil {
+		c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	if req.ClassName == "" || req.FieldName == "" {
+		c.JSON(http.StatusBadRequest, map[string]string{"error": "className and fieldName are required"})
+		return
+	}
+
+	raw, err := h.manager.AgentInvoke(sessionID, "classes", "readField", []any{req.ClassName, req.FieldName})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(http.StatusOK)
+	c.Writer.Write(raw) //nolint:errcheck
+}

--- a/internal/features/sessions/list/handler.go
+++ b/internal/features/sessions/list/handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 var platformCapabilities = map[string][]string{
-	"android": {"filesystem", "database", "logstream"},
+	"android": {"filesystem", "database", "logstream", "frida"},
 	"ios":     {},
 }
 

--- a/internal/features/sessions/routes.go
+++ b/internal/features/sessions/routes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/joakimcarlsson/juicebox/internal/db"
 	"github.com/joakimcarlsson/juicebox/internal/features/sessions/attach"
 	"github.com/joakimcarlsson/juicebox/internal/features/sessions/chat"
+	"github.com/joakimcarlsson/juicebox/internal/features/sessions/classes"
 	"github.com/joakimcarlsson/juicebox/internal/features/sessions/detach"
 	"github.com/joakimcarlsson/juicebox/internal/features/sessions/filesystem"
 	"github.com/joakimcarlsson/juicebox/internal/features/sessions/intercept"
@@ -28,6 +29,7 @@ func RegisterRoutes(r *router.Router, manager *session.Manager, database *db.DB,
 	chatHandler := chat.NewHandler(database, manager, &appConfig.LLM, chatStore, sqliteHandler)
 	interceptHandler := intercept.NewHandler(manager)
 	fsHandler := filesystem.NewHandler(manager)
+	classesHandler := classes.NewHandler(manager)
 
 	r.POST("/devices/{deviceId}/apps/{bundleId}/attach", attachHandler.Handle)
 	r.DELETE("/sessions/{sessionId}", detachHandler.Handle)
@@ -51,4 +53,9 @@ func RegisterRoutes(r *router.Router, manager *session.Manager, database *db.DB,
 	r.GET("/sessions/{sessionId}/sqlite/tables", sqliteHandler.Tables)
 	r.POST("/sessions/{sessionId}/sqlite/query", sqliteHandler.Query)
 	r.GET("/sessions/{sessionId}/sqlite/export", sqliteHandler.Export)
+
+	r.GET("/sessions/{sessionId}/classes", classesHandler.List)
+	r.GET("/sessions/{sessionId}/classes/detail", classesHandler.Detail)
+	r.POST("/sessions/{sessionId}/classes/invoke", classesHandler.Invoke)
+	r.POST("/sessions/{sessionId}/classes/read-field", classesHandler.ReadField)
 }

--- a/internal/session/android_setup.go
+++ b/internal/session/android_setup.go
@@ -68,5 +68,5 @@ func (a *AndroidSetup) ListProcesses(deviceId string) ([]bridge.Process, error) 
 }
 
 func (a *AndroidSetup) Capabilities() []string {
-	return []string{"filesystem", "database", "logstream"}
+	return []string{"filesystem", "database", "logstream", "frida"}
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -255,6 +255,16 @@ func (m *Manager) GetSession(sessionId string) *Session {
 	return m.sessions[sessionId]
 }
 
+func (m *Manager) AgentInvoke(sessionID, namespace, method string, args []any) (json.RawMessage, error) {
+	m.mu.RLock()
+	sess, ok := m.sessions[sessionID]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("session %s not found", sessionID)
+	}
+	return m.bridge.AgentInvoke(sess.BridgeSession, namespace, method, args)
+}
+
 func (m *Manager) bridgeSubscribeForward(sess *Session) {
 	logger := slog.With("device_id", sess.DeviceID, "source", "manager", "session_id", sess.ID)
 

--- a/web/src/components/classes/ClassBrowser.tsx
+++ b/web/src/components/classes/ClassBrowser.tsx
@@ -1,0 +1,168 @@
+import { useState, useCallback } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { listClassesQueryOptions } from "@/features/classes/queries"
+import { ClassDetail } from "./ClassDetail"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Search, ChevronLeft, ChevronRight, AlertCircle, Blocks } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+interface ClassBrowserProps {
+  sessionId: string
+}
+
+const PAGE_SIZE = 100
+
+export function ClassBrowser({ sessionId }: ClassBrowserProps) {
+  const [searchInput, setSearchInput] = useState("")
+  const [query, setQuery] = useState("")
+  const [page, setPage] = useState(0)
+  const [selectedClass, setSelectedClass] = useState<string | null>(null)
+
+  const { data, isLoading, error } = useQuery(
+    listClassesQueryOptions(sessionId, query, PAGE_SIZE, page * PAGE_SIZE),
+  )
+
+  const handleSearch = useCallback(() => {
+    setQuery(searchInput.trim())
+    setPage(0)
+    setSelectedClass(null)
+  }, [searchInput])
+
+  const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0
+
+  return (
+    <div className="flex h-full overflow-hidden">
+      <div className="flex flex-col w-80 shrink-0 border-r border-border overflow-hidden">
+        <div className="px-3 py-2 border-b border-border shrink-0">
+          <div className="flex items-center gap-1">
+            <div className="relative flex-1">
+              <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                placeholder="Search classes..."
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleSearch()
+                }}
+                className="pl-7 h-7 text-xs"
+              />
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 shrink-0"
+              onClick={handleSearch}
+            >
+              <Search className="h-3 w-3" />
+            </Button>
+          </div>
+        </div>
+
+        {isLoading && (
+          <div className="p-3 space-y-2">
+            {Array.from({ length: 12 }).map((_, i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+          </div>
+        )}
+
+        {error && (
+          <div className="flex items-center gap-2 p-4 text-sm text-destructive">
+            <AlertCircle className="h-4 w-4 shrink-0" />
+            <span className="text-xs">{error.message}</span>
+          </div>
+        )}
+
+        {data && !isLoading && (
+          <>
+            <div className="px-3 py-1.5 border-b border-border shrink-0">
+              <span className="text-[10px] text-muted-foreground">
+                {data.total.toLocaleString()} classes
+                {query && (
+                  <> matching <span className="text-foreground font-medium">"{query}"</span></>
+                )}
+              </span>
+            </div>
+            <ScrollArea className="flex-1 min-h-0">
+              {data.classes.length === 0 ? (
+                <div className="flex flex-col items-center justify-center p-8 text-muted-foreground">
+                  <Blocks className="h-8 w-8 mb-2 opacity-50" />
+                  <p className="text-xs">No classes found</p>
+                </div>
+              ) : (
+                <div>
+                  {data.classes.map((cls) => {
+                    const parts = cls.split(".")
+                    const name = parts.pop()!
+                    const pkg = parts.join(".")
+                    return (
+                      <button
+                        key={cls}
+                        onClick={() => setSelectedClass(cls)}
+                        className={cn(
+                          "flex flex-col w-full px-3 py-1.5 text-left hover:bg-muted/50 transition-colors",
+                          selectedClass === cls && "bg-muted",
+                        )}
+                      >
+                        <span className="text-xs font-mono text-foreground truncate">
+                          {name}
+                        </span>
+                        {pkg && (
+                          <span className="text-[10px] font-mono text-muted-foreground truncate">
+                            {pkg}
+                          </span>
+                        )}
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </ScrollArea>
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between px-3 py-1.5 border-t border-border shrink-0">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  disabled={page === 0}
+                  onClick={() => setPage((p) => p - 1)}
+                >
+                  <ChevronLeft className="h-3 w-3" />
+                </Button>
+                <span className="text-[10px] text-muted-foreground">
+                  {page + 1} / {totalPages}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  disabled={page >= totalPages - 1}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  <ChevronRight className="h-3 w-3" />
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-hidden">
+        {selectedClass ? (
+          <ClassDetail sessionId={sessionId} className={selectedClass} />
+        ) : (
+          <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
+            <Blocks className="h-10 w-10 mb-3 opacity-30" />
+            <p className="text-sm">Select a class to inspect</p>
+            <p className="text-xs mt-1">
+              Search for classes by package name or keyword
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/classes/ClassDetail.tsx
+++ b/web/src/components/classes/ClassDetail.tsx
@@ -1,0 +1,416 @@
+import { useState } from "react"
+import { useQuery, useMutation } from "@tanstack/react-query"
+import { classDetailQueryOptions } from "@/features/classes/queries"
+import { invokeMethod, readField } from "@/features/classes/api"
+import type { MethodInfo, FieldInfo } from "@/features/classes/api"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Skeleton } from "@/components/ui/skeleton"
+import { cn } from "@/lib/utils"
+import {
+  Play,
+  Eye,
+  ChevronRight,
+  AlertCircle,
+  Lock,
+  Unlock,
+  Zap,
+  Hash,
+  Shield,
+} from "lucide-react"
+
+interface ClassDetailProps {
+  sessionId: string
+  className: string
+}
+
+const MODIFIER_FLAGS: [number, string][] = [
+  [0x0001, "public"],
+  [0x0002, "private"],
+  [0x0004, "protected"],
+  [0x0008, "static"],
+  [0x0010, "final"],
+  [0x0020, "synchronized"],
+  [0x0040, "volatile"],
+  [0x0080, "transient"],
+  [0x0100, "native"],
+  [0x0400, "abstract"],
+]
+
+function modifierTags(modifiers: number) {
+  return MODIFIER_FLAGS.filter(([flag]) => (modifiers & flag) !== 0).map(
+    ([, name]) => name,
+  )
+}
+
+function modifierIcon(modifiers: number) {
+  if (modifiers & 0x0001) return <Unlock className="h-3 w-3 text-emerald-500" />
+  if (modifiers & 0x0002) return <Lock className="h-3 w-3 text-red-400" />
+  if (modifiers & 0x0004) return <Shield className="h-3 w-3 text-amber-400" />
+  return <Hash className="h-3 w-3 text-muted-foreground" />
+}
+
+type ActiveTab = "methods" | "fields" | "hierarchy"
+
+export function ClassDetail({ sessionId, className }: ClassDetailProps) {
+  const [tab, setTab] = useState<ActiveTab>("methods")
+  const { data, isLoading, error } = useQuery(classDetailQueryOptions(sessionId, className))
+
+  if (isLoading) {
+    return (
+      <div className="p-4 space-y-3">
+        <Skeleton className="h-5 w-48" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-1/2" />
+      </div>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex items-center gap-2 p-4 text-sm text-destructive">
+        <AlertCircle className="h-4 w-4" />
+        {error?.message ?? "Failed to load class detail"}
+      </div>
+    )
+  }
+
+  const tabs: { value: ActiveTab; label: string; count: number }[] = [
+    { value: "methods", label: "Methods", count: data.methods.length },
+    { value: "fields", label: "Fields", count: data.fields.length },
+    {
+      value: "hierarchy",
+      label: "Hierarchy",
+      count: data.interfaces.length + data.superclasses.length,
+    },
+  ]
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="shrink-0 border-b border-border px-4 py-2">
+        <p className="text-xs font-mono text-foreground truncate">{className}</p>
+      </div>
+      <div className="flex items-center gap-0.5 border-b border-border px-2 shrink-0">
+        {tabs.map((t) => (
+          <button
+            key={t.value}
+            onClick={() => setTab(t.value)}
+            className={cn(
+              "flex items-center gap-1.5 px-3 h-8 text-xs transition-colors border-b-2 border-transparent",
+              tab === t.value
+                ? "border-foreground text-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {t.label}
+            <span className="text-muted-foreground/70">{t.count}</span>
+          </button>
+        ))}
+      </div>
+      <ScrollArea className="flex-1">
+        {tab === "methods" && (
+          <MethodsTab sessionId={sessionId} className={className} methods={data.methods} />
+        )}
+        {tab === "fields" && (
+          <FieldsTab sessionId={sessionId} className={className} fields={data.fields} />
+        )}
+        {tab === "hierarchy" && (
+          <HierarchyTab interfaces={data.interfaces} superclasses={data.superclasses} />
+        )}
+      </ScrollArea>
+    </div>
+  )
+}
+
+function MethodsTab({
+  sessionId,
+  className,
+  methods,
+}: {
+  sessionId: string
+  className: string
+  methods: MethodInfo[]
+}) {
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(null)
+
+  if (methods.length === 0) {
+    return <p className="p-4 text-xs text-muted-foreground">No declared methods.</p>
+  }
+
+  return (
+    <div className="divide-y divide-border">
+      {methods.map((m, i) => (
+        <MethodRow
+          key={`${m.name}-${i}`}
+          sessionId={sessionId}
+          className={className}
+          method={m}
+          expanded={expandedIdx === i}
+          onToggle={() => setExpandedIdx(expandedIdx === i ? null : i)}
+        />
+      ))}
+    </div>
+  )
+}
+
+function MethodRow({
+  sessionId,
+  className,
+  method,
+  expanded,
+  onToggle,
+}: {
+  sessionId: string
+  className: string
+  method: MethodInfo
+  expanded: boolean
+  onToggle: () => void
+}) {
+  const [args, setArgs] = useState("")
+  const invoke = useMutation({
+    mutationFn: () => {
+      const parsed = args.trim() ? args.split(",").map((a) => a.trim()) : []
+      return invokeMethod(sessionId, className, method.name, parsed)
+    },
+  })
+
+  const mods = modifierTags(method.modifiers)
+  const isStatic = (method.modifiers & 0x0008) !== 0
+  const paramSig = method.parameterTypes.map((p) => p.split(".").pop()).join(", ")
+
+  return (
+    <div className="group">
+      <button
+        onClick={onToggle}
+        className="flex items-center gap-2 w-full px-4 py-2 text-left hover:bg-muted/50 transition-colors"
+      >
+        <ChevronRight
+          className={cn(
+            "h-3 w-3 shrink-0 text-muted-foreground transition-transform",
+            expanded && "rotate-90",
+          )}
+        />
+        {modifierIcon(method.modifiers)}
+        <span className="text-xs font-mono text-foreground truncate">
+          {method.name}
+        </span>
+        <span className="text-xs font-mono text-muted-foreground truncate">
+          ({paramSig})
+        </span>
+        <ChevronRight className="h-2.5 w-2.5 text-muted-foreground/50 shrink-0 mx-0.5" />
+        <span className="text-xs font-mono text-muted-foreground truncate">
+          {method.returnType.split(".").pop()}
+        </span>
+        {isStatic && (
+          <Badge variant="outline" className="ml-auto text-[10px] px-1.5 py-0 h-4 shrink-0">
+            static
+          </Badge>
+        )}
+      </button>
+      {expanded && (
+        <div className="px-4 pb-3 pt-1 bg-muted/30 space-y-2">
+          <div className="flex flex-wrap gap-1">
+            {mods.map((m) => (
+              <Badge key={m} variant="secondary" className="text-[10px] px-1.5 py-0 h-4">
+                {m}
+              </Badge>
+            ))}
+          </div>
+          {method.parameterTypes.length > 0 && (
+            <div className="text-xs text-muted-foreground font-mono space-y-0.5">
+              {method.parameterTypes.map((p, i) => (
+                <div key={i}>
+                  <span className="text-muted-foreground/70">arg{i}: </span>
+                  {p}
+                </div>
+              ))}
+            </div>
+          )}
+          <div className="text-xs font-mono text-muted-foreground">
+            <span className="text-muted-foreground/70">returns: </span>
+            {method.returnType}
+          </div>
+          <div className="flex items-center gap-2 pt-1">
+            {method.parameterTypes.length > 0 && (
+              <Input
+                placeholder="arg1, arg2, ..."
+                value={args}
+                onChange={(e) => setArgs(e.target.value)}
+                className="h-7 text-xs font-mono flex-1"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") invoke.mutate()
+                }}
+              />
+            )}
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 text-xs gap-1 shrink-0"
+              onClick={() => invoke.mutate()}
+              disabled={invoke.isPending}
+            >
+              <Play className="h-3 w-3" />
+              Invoke
+            </Button>
+          </div>
+          {invoke.data && (
+            <div
+              className={cn(
+                "text-xs font-mono p-2 rounded border",
+                invoke.data.error
+                  ? "bg-destructive/10 border-destructive/20 text-destructive"
+                  : "bg-muted border-border text-foreground",
+              )}
+            >
+              {invoke.data.error ?? invoke.data.value ?? "null"}
+            </div>
+          )}
+          {invoke.error && (
+            <div className="text-xs text-destructive">
+              {invoke.error.message}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function FieldsTab({
+  sessionId,
+  className,
+  fields,
+}: {
+  sessionId: string
+  className: string
+  fields: FieldInfo[]
+}) {
+  if (fields.length === 0) {
+    return <p className="p-4 text-xs text-muted-foreground">No declared fields.</p>
+  }
+
+  return (
+    <div className="divide-y divide-border">
+      {fields.map((f, i) => (
+        <FieldRow
+          key={`${f.name}-${i}`}
+          sessionId={sessionId}
+          className={className}
+          field={f}
+        />
+      ))}
+    </div>
+  )
+}
+
+function FieldRow({
+  sessionId,
+  className,
+  field,
+}: {
+  sessionId: string
+  className: string
+  field: FieldInfo
+}) {
+  const read = useMutation({
+    mutationFn: () => readField(sessionId, className, field.name),
+  })
+
+  const mods = modifierTags(field.modifiers)
+  const isStatic = (field.modifiers & 0x0008) !== 0
+
+  return (
+    <div className="px-4 py-2 hover:bg-muted/50 transition-colors">
+      <div className="flex items-center gap-2">
+        {modifierIcon(field.modifiers)}
+        <span className="text-xs font-mono text-foreground truncate">{field.name}</span>
+        <span className="text-xs font-mono text-muted-foreground truncate">
+          : {field.type.split(".").pop()}
+        </span>
+        <div className="flex items-center gap-1 ml-auto shrink-0">
+          {mods.includes("static") && (
+            <Badge variant="outline" className="text-[10px] px-1.5 py-0 h-4">
+              static
+            </Badge>
+          )}
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-6 w-6 p-0"
+            onClick={() => read.mutate()}
+            disabled={read.isPending}
+          >
+            <Eye className="h-3 w-3" />
+          </Button>
+        </div>
+      </div>
+      {field.value !== null && field.value !== undefined && (
+        <div className="mt-1 text-xs font-mono text-muted-foreground pl-5 truncate">
+          = {String(field.value)}
+        </div>
+      )}
+      {read.data && (
+        <div
+          className={cn(
+            "mt-1 text-xs font-mono p-1.5 rounded border ml-5",
+            read.data.error
+              ? "bg-destructive/10 border-destructive/20 text-destructive"
+              : "bg-muted border-border text-foreground",
+          )}
+        >
+          {read.data.error ?? read.data.value ?? "null"}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function HierarchyTab({
+  interfaces,
+  superclasses,
+}: {
+  interfaces: string[]
+  superclasses: string[]
+}) {
+  return (
+    <div className="p-4 space-y-4">
+      {superclasses.length > 0 && (
+        <div>
+          <p className="text-xs font-medium text-muted-foreground mb-2">Superclass Chain</p>
+          <div className="space-y-1">
+            {superclasses.map((s, i) => (
+              <div key={s} className="flex items-center gap-1.5">
+                {i > 0 && (
+                  <span className="text-muted-foreground/40 text-xs" style={{ paddingLeft: i * 12 }}>
+                    {"↳"}
+                  </span>
+                )}
+                <Zap className="h-3 w-3 text-muted-foreground shrink-0" />
+                <span className="text-xs font-mono text-foreground">{s}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {interfaces.length > 0 && (
+        <div>
+          <p className="text-xs font-medium text-muted-foreground mb-2">Interfaces</p>
+          <div className="flex flex-wrap gap-1.5">
+            {interfaces.map((iface) => (
+              <Badge key={iface} variant="secondary" className="text-[10px] font-mono px-2 py-0.5">
+                {iface}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+      {superclasses.length === 0 && interfaces.length === 0 && (
+        <p className="text-xs text-muted-foreground">No hierarchy information.</p>
+      )}
+    </div>
+  )
+}

--- a/web/src/features/classes/api.ts
+++ b/web/src/features/classes/api.ts
@@ -1,0 +1,94 @@
+export interface ClassListResponse {
+  classes: string[]
+  total: number
+}
+
+export interface MethodInfo {
+  name: string
+  parameterTypes: string[]
+  returnType: string
+  modifiers: number
+}
+
+export interface FieldInfo {
+  name: string
+  type: string
+  modifiers: number
+  value: unknown
+}
+
+export interface ClassDetail {
+  className: string
+  methods: MethodInfo[]
+  fields: FieldInfo[]
+  interfaces: string[]
+  superclasses: string[]
+}
+
+export interface InvokeResult {
+  value?: string | null
+  error?: string
+}
+
+export async function listClasses(
+  sessionId: string,
+  query: string,
+  limit = 100,
+  offset = 0,
+): Promise<ClassListResponse> {
+  const params = new URLSearchParams({ query, limit: String(limit), offset: String(offset) })
+  const res = await fetch(`/api/v1/sessions/${sessionId}/classes?${params}`)
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    throw new Error((data as { error?: string }).error ?? "Failed to list classes")
+  }
+  return res.json()
+}
+
+export async function getClassDetail(
+  sessionId: string,
+  className: string,
+): Promise<ClassDetail> {
+  const params = new URLSearchParams({ className })
+  const res = await fetch(`/api/v1/sessions/${sessionId}/classes/detail?${params}`)
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    throw new Error((data as { error?: string }).error ?? "Failed to get class detail")
+  }
+  return res.json()
+}
+
+export async function invokeMethod(
+  sessionId: string,
+  className: string,
+  methodName: string,
+  args: string[] = [],
+): Promise<InvokeResult> {
+  const res = await fetch(`/api/v1/sessions/${sessionId}/classes/invoke`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ className, methodName, args }),
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    throw new Error((data as { error?: string }).error ?? "Failed to invoke method")
+  }
+  return res.json()
+}
+
+export async function readField(
+  sessionId: string,
+  className: string,
+  fieldName: string,
+): Promise<InvokeResult> {
+  const res = await fetch(`/api/v1/sessions/${sessionId}/classes/read-field`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ className, fieldName }),
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    throw new Error((data as { error?: string }).error ?? "Failed to read field")
+  }
+  return res.json()
+}

--- a/web/src/features/classes/queries.ts
+++ b/web/src/features/classes/queries.ts
@@ -1,0 +1,20 @@
+import { queryOptions } from "@tanstack/react-query"
+import { listClasses, getClassDetail } from "./api"
+
+export function listClassesQueryOptions(sessionId: string, query: string, limit = 100, offset = 0) {
+  return queryOptions({
+    queryKey: ["sessions", sessionId, "classes", query, limit, offset],
+    queryFn: () => listClasses(sessionId, query, limit, offset),
+    enabled: !!sessionId,
+    staleTime: 30_000,
+  })
+}
+
+export function classDetailQueryOptions(sessionId: string, className: string) {
+  return queryOptions({
+    queryKey: ["sessions", sessionId, "classes", "detail", className],
+    queryFn: () => getClassDetail(sessionId, className),
+    enabled: !!sessionId && !!className,
+    staleTime: 60_000,
+  })
+}

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as DevicesDeviceIdAppBundleIdNetworkRouteImport } from './routes/
 import { Route as DevicesDeviceIdAppBundleIdLogsRouteImport } from './routes/devices/$deviceId/app/$bundleId/logs'
 import { Route as DevicesDeviceIdAppBundleIdHomeRouteImport } from './routes/devices/$deviceId/app/$bundleId/home'
 import { Route as DevicesDeviceIdAppBundleIdFilesRouteImport } from './routes/devices/$deviceId/app/$bundleId/files'
+import { Route as DevicesDeviceIdAppBundleIdClassesRouteImport } from './routes/devices/$deviceId/app/$bundleId/classes'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -83,6 +84,12 @@ const DevicesDeviceIdAppBundleIdFilesRoute =
     path: '/files',
     getParentRoute: () => DevicesDeviceIdAppBundleIdRoute,
   } as any)
+const DevicesDeviceIdAppBundleIdClassesRoute =
+  DevicesDeviceIdAppBundleIdClassesRouteImport.update({
+    id: '/classes',
+    path: '/classes',
+    getParentRoute: () => DevicesDeviceIdAppBundleIdRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -91,6 +98,7 @@ export interface FileRoutesByFullPath {
   '/devices/$deviceId/processes': typeof DevicesDeviceIdProcessesRoute
   '/devices/$deviceId/': typeof DevicesDeviceIdIndexRoute
   '/devices/$deviceId/app/$bundleId': typeof DevicesDeviceIdAppBundleIdRouteWithChildren
+  '/devices/$deviceId/app/$bundleId/classes': typeof DevicesDeviceIdAppBundleIdClassesRoute
   '/devices/$deviceId/app/$bundleId/files': typeof DevicesDeviceIdAppBundleIdFilesRoute
   '/devices/$deviceId/app/$bundleId/home': typeof DevicesDeviceIdAppBundleIdHomeRoute
   '/devices/$deviceId/app/$bundleId/logs': typeof DevicesDeviceIdAppBundleIdLogsRoute
@@ -102,6 +110,7 @@ export interface FileRoutesByTo {
   '/devices/$deviceId/apps': typeof DevicesDeviceIdAppsRoute
   '/devices/$deviceId/processes': typeof DevicesDeviceIdProcessesRoute
   '/devices/$deviceId': typeof DevicesDeviceIdIndexRoute
+  '/devices/$deviceId/app/$bundleId/classes': typeof DevicesDeviceIdAppBundleIdClassesRoute
   '/devices/$deviceId/app/$bundleId/files': typeof DevicesDeviceIdAppBundleIdFilesRoute
   '/devices/$deviceId/app/$bundleId/home': typeof DevicesDeviceIdAppBundleIdHomeRoute
   '/devices/$deviceId/app/$bundleId/logs': typeof DevicesDeviceIdAppBundleIdLogsRoute
@@ -116,6 +125,7 @@ export interface FileRoutesById {
   '/devices/$deviceId/processes': typeof DevicesDeviceIdProcessesRoute
   '/devices/$deviceId/': typeof DevicesDeviceIdIndexRoute
   '/devices/$deviceId/app/$bundleId': typeof DevicesDeviceIdAppBundleIdRouteWithChildren
+  '/devices/$deviceId/app/$bundleId/classes': typeof DevicesDeviceIdAppBundleIdClassesRoute
   '/devices/$deviceId/app/$bundleId/files': typeof DevicesDeviceIdAppBundleIdFilesRoute
   '/devices/$deviceId/app/$bundleId/home': typeof DevicesDeviceIdAppBundleIdHomeRoute
   '/devices/$deviceId/app/$bundleId/logs': typeof DevicesDeviceIdAppBundleIdLogsRoute
@@ -131,6 +141,7 @@ export interface FileRouteTypes {
     | '/devices/$deviceId/processes'
     | '/devices/$deviceId/'
     | '/devices/$deviceId/app/$bundleId'
+    | '/devices/$deviceId/app/$bundleId/classes'
     | '/devices/$deviceId/app/$bundleId/files'
     | '/devices/$deviceId/app/$bundleId/home'
     | '/devices/$deviceId/app/$bundleId/logs'
@@ -142,6 +153,7 @@ export interface FileRouteTypes {
     | '/devices/$deviceId/apps'
     | '/devices/$deviceId/processes'
     | '/devices/$deviceId'
+    | '/devices/$deviceId/app/$bundleId/classes'
     | '/devices/$deviceId/app/$bundleId/files'
     | '/devices/$deviceId/app/$bundleId/home'
     | '/devices/$deviceId/app/$bundleId/logs'
@@ -155,6 +167,7 @@ export interface FileRouteTypes {
     | '/devices/$deviceId/processes'
     | '/devices/$deviceId/'
     | '/devices/$deviceId/app/$bundleId'
+    | '/devices/$deviceId/app/$bundleId/classes'
     | '/devices/$deviceId/app/$bundleId/files'
     | '/devices/$deviceId/app/$bundleId/home'
     | '/devices/$deviceId/app/$bundleId/logs'
@@ -246,10 +259,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DevicesDeviceIdAppBundleIdFilesRouteImport
       parentRoute: typeof DevicesDeviceIdAppBundleIdRoute
     }
+    '/devices/$deviceId/app/$bundleId/classes': {
+      id: '/devices/$deviceId/app/$bundleId/classes'
+      path: '/classes'
+      fullPath: '/devices/$deviceId/app/$bundleId/classes'
+      preLoaderRoute: typeof DevicesDeviceIdAppBundleIdClassesRouteImport
+      parentRoute: typeof DevicesDeviceIdAppBundleIdRoute
+    }
   }
 }
 
 interface DevicesDeviceIdAppBundleIdRouteChildren {
+  DevicesDeviceIdAppBundleIdClassesRoute: typeof DevicesDeviceIdAppBundleIdClassesRoute
   DevicesDeviceIdAppBundleIdFilesRoute: typeof DevicesDeviceIdAppBundleIdFilesRoute
   DevicesDeviceIdAppBundleIdHomeRoute: typeof DevicesDeviceIdAppBundleIdHomeRoute
   DevicesDeviceIdAppBundleIdLogsRoute: typeof DevicesDeviceIdAppBundleIdLogsRoute
@@ -259,6 +280,8 @@ interface DevicesDeviceIdAppBundleIdRouteChildren {
 
 const DevicesDeviceIdAppBundleIdRouteChildren: DevicesDeviceIdAppBundleIdRouteChildren =
   {
+    DevicesDeviceIdAppBundleIdClassesRoute:
+      DevicesDeviceIdAppBundleIdClassesRoute,
     DevicesDeviceIdAppBundleIdFilesRoute: DevicesDeviceIdAppBundleIdFilesRoute,
     DevicesDeviceIdAppBundleIdHomeRoute: DevicesDeviceIdAppBundleIdHomeRoute,
     DevicesDeviceIdAppBundleIdLogsRoute: DevicesDeviceIdAppBundleIdLogsRoute,

--- a/web/src/routes/devices/$deviceId/app/$bundleId.tsx
+++ b/web/src/routes/devices/$deviceId/app/$bundleId.tsx
@@ -22,7 +22,7 @@ import {
   ResizableHandle,
 } from "@/components/ui/resizable"
 import { useDefaultLayout } from "react-resizable-panels"
-import { ArrowLeft, Home, Globe, FileText, Code, Terminal, MessageSquare, FolderOpen } from "lucide-react"
+import { ArrowLeft, Home, Globe, FileText, Code, Terminal, MessageSquare, FolderOpen, Blocks } from "lucide-react"
 import { useEffect, useRef, useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { appSessionsQueryOptions } from "@/features/sessions/queries"
@@ -44,6 +44,7 @@ function getTabs(capabilities: string[] | null) {
     { value: "network", label: "Network", icon: Globe, enabled: true, to: "/devices/$deviceId/app/$bundleId/network" as const },
     { value: "logs", label: "Logs", icon: FileText, enabled: has("logstream"), to: "/devices/$deviceId/app/$bundleId/logs" as const },
     { value: "files", label: "Files", icon: FolderOpen, enabled: has("filesystem"), to: "/devices/$deviceId/app/$bundleId/files" as const },
+    { value: "classes", label: "Classes", icon: Blocks, enabled: has("frida"), to: "/devices/$deviceId/app/$bundleId/classes" as const },
     { value: "hooks", label: "Hooks", icon: Code, enabled: false, to: "/devices/$deviceId/app/$bundleId/network" as const },
   ]
 }

--- a/web/src/routes/devices/$deviceId/app/$bundleId/classes.tsx
+++ b/web/src/routes/devices/$deviceId/app/$bundleId/classes.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute, useSearch } from "@tanstack/react-router"
+import { ClassBrowser } from "@/components/classes/ClassBrowser"
+import { NoSessionEmptyState } from "@/components/sessions/NoSessionEmptyState"
+
+export const Route = createFileRoute(
+  "/devices/$deviceId/app/$bundleId/classes",
+)({
+  validateSearch: (search: Record<string, unknown>) => ({
+    sessionId: (search.sessionId as string) ?? "",
+  }),
+  component: ClassesPage,
+})
+
+function ClassesPage() {
+  const { sessionId } = useSearch({
+    from: "/devices/$deviceId/app/$bundleId/classes",
+  })
+
+  if (!sessionId) {
+    return <NoSessionEmptyState />
+  }
+
+  return <ClassBrowser sessionId={sessionId} />
+}

--- a/web/src/routes/devices/$deviceId/app/$bundleId/home.tsx
+++ b/web/src/routes/devices/$deviceId/app/$bundleId/home.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link, useParams, useSearch } from "@tanstack/react-router"
 import { useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { Globe, FileText, FolderOpen } from "lucide-react"
+import { Globe, FileText, FolderOpen, Blocks } from "lucide-react"
 import { appSessionsQueryOptions } from "@/features/sessions/queries"
 import { cn } from "@/lib/utils"
 
@@ -37,6 +37,14 @@ const ALL_MODULES = [
     icon: FolderOpen,
     to: "/devices/$deviceId/app/$bundleId/files" as const,
     capability: "filesystem",
+  },
+  {
+    value: "classes",
+    label: "Classes",
+    description: "Browse loaded Java classes, methods, fields, and interfaces",
+    icon: Blocks,
+    to: "/devices/$deviceId/app/$bundleId/classes" as const,
+    capability: "frida",
   },
 ]
 


### PR DESCRIPTION
closes #3 

This pull request introduces a new Java class inspection and manipulation capability to the agent and backend, enabling runtime introspection and interaction with Java classes in Android app sessions. The changes add a new `classes` module to the agent, expose new HTTP API endpoints, and provide chat tools for listing classes, inspecting class details, invoking static methods, and reading static fields. This is achieved by integrating the `frida-java-bridge` library and updating the capability system.