### PR TITLE
feat(crash): implement crash reporting and handling features, including database schema, API endpoints, and UI components for crash display

### DIFF
--- a/agent/src/modules/crash.ts
+++ b/agent/src/modules/crash.ts
@@ -1,0 +1,147 @@
+/// <reference types="npm:@types/frida-gum" />
+
+import type { AgentModule } from "../types";
+import Java from "frida-java-bridge";
+
+let _enabled = false;
+let _counter = 0;
+
+const FATAL_TYPES = new Set([
+  "abort",
+  "illegal-instruction",
+  "guard-page",
+  "arithmetic",
+]);
+
+function generateId(): string {
+  return `crash-${Date.now()}-${++_counter}`;
+}
+
+function readRegisters(ctx: CpuContext): Record<string, string> {
+  const regs: Record<string, string> = {};
+  const keys = Object.getOwnPropertyNames(Object.getPrototypeOf(ctx))
+    .filter((k) => k !== "constructor" && k !== "toJSON");
+  for (const key of keys) {
+    try {
+      const val = (ctx as any)[key];
+      if (val instanceof NativePointer) {
+        regs[key] = val.toString();
+      }
+    } catch (_) {}
+  }
+  return regs;
+}
+
+function enableNative(): void {
+  Process.setExceptionHandler((details) => {
+    if (!FATAL_TYPES.has(details.type)) return false;
+
+    const frames = Thread.backtrace(details.context, Backtracer.ACCURATE);
+    const backtrace = frames.map((addr) => {
+      const sym = DebugSymbol.fromAddress(addr);
+      return sym.toString();
+    });
+
+    const registers = readRegisters(details.context);
+
+    send({
+      type: "crash",
+      payload: {
+        id: generateId(),
+        crashType: "native",
+        signal: details.type ?? null,
+        address: details.address?.toString() ?? null,
+        registers,
+        backtrace,
+        javaStackTrace: null,
+        exceptionClass: null,
+        exceptionMessage: null,
+        timestamp: Date.now(),
+      },
+    });
+
+    return false;
+  });
+}
+
+function enableJava(): void {
+  if (!Java.available) return;
+
+  setTimeout(() => {
+    Java.perform(() => {
+      const Thread = Java.use("java.lang.Thread");
+      const UncaughtHandler = Java.use("java.lang.Thread$UncaughtExceptionHandler");
+
+      const previousHandler = Thread.getDefaultUncaughtExceptionHandler();
+
+      const CrashHandler = Java.registerClass({
+        name: "com.juicebox.CrashHandler",
+        implements: [UncaughtHandler],
+        methods: {
+          uncaughtException(thread: any, throwable: any) {
+            try {
+              const exceptionClass = throwable.getClass().getName();
+              const exceptionMessage = throwable.getMessage()?.toString() ?? "";
+
+              const stackElements = throwable.getStackTrace();
+              const lines: string[] = [];
+              for (let i = 0; i < stackElements.length; i++) {
+                lines.push(stackElements[i].toString());
+              }
+
+              let fullTrace = `${exceptionClass}: ${exceptionMessage}`;
+              for (const line of lines) {
+                fullTrace += `\n    at ${line}`;
+              }
+
+              let cause = throwable.getCause();
+              while (cause !== null) {
+                const causeClass = cause.getClass().getName();
+                const causeMsg = cause.getMessage()?.toString() ?? "";
+                fullTrace += `\nCaused by: ${causeClass}: ${causeMsg}`;
+                const causeStack = cause.getStackTrace();
+                for (let i = 0; i < causeStack.length; i++) {
+                  fullTrace += `\n    at ${causeStack[i].toString()}`;
+                }
+                cause = cause.getCause();
+              }
+
+              send({
+                type: "crash",
+                payload: {
+                  id: generateId(),
+                  crashType: "java",
+                  signal: null,
+                  address: null,
+                  registers: null,
+                  backtrace: [],
+                  javaStackTrace: fullTrace,
+                  exceptionClass,
+                  exceptionMessage,
+                  timestamp: Date.now(),
+                },
+              });
+            } catch (_) {}
+
+            if (previousHandler !== null) {
+              previousHandler.uncaughtException(thread, throwable);
+            }
+          },
+        },
+      });
+
+      Thread.setDefaultUncaughtExceptionHandler(CrashHandler.$new());
+    });
+  }, 0);
+}
+
+function enable(): { enabled: boolean } {
+  if (_enabled) return { enabled: true };
+  enableNative();
+  enableJava();
+  _enabled = true;
+  return { enabled: true };
+}
+
+const crash: AgentModule = { enable };
+export default crash;

--- a/agent/src/router.ts
+++ b/agent/src/router.ts
@@ -1,8 +1,9 @@
 import type { AgentModule } from "./types";
 import ssl from "./modules/ssl";
 import classes from "./modules/classes";
+import crash from "./modules/crash";
 
-const registry: Record<string, AgentModule> = { ssl, classes };
+const registry: Record<string, AgentModule> = { ssl, classes, crash };
 
 export function getModule(namespace: string): AgentModule | undefined {
   return registry[namespace];

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -55,6 +55,21 @@ CREATE TABLE IF NOT EXISTS hook_events (
     timestamp  INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_hook_session ON hook_events(session_id);
+
+CREATE TABLE IF NOT EXISTS crashes (
+    id                TEXT PRIMARY KEY,
+    session_id        TEXT NOT NULL REFERENCES sessions(id),
+    crash_type        TEXT NOT NULL,
+    signal            TEXT,
+    address           TEXT,
+    registers         TEXT,
+    backtrace         TEXT,
+    java_stack_trace  TEXT,
+    exception_class   TEXT,
+    exception_message TEXT,
+    timestamp         INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_crashes_session ON crashes(session_id, timestamp);
 `
 
 func (d *DB) Migrate() error {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -351,6 +351,94 @@ func (d *DB) SearchHttpMessages(sessionID, method, host string, statusCode *int,
 	return result, rows.Err()
 }
 
+type CrashRow struct {
+	ID               string
+	SessionID        string
+	CrashType        string
+	Signal           *string
+	Address          *string
+	Registers        *string
+	Backtrace        *string
+	JavaStackTrace   *string
+	ExceptionClass   *string
+	ExceptionMessage *string
+	Timestamp        int64
+}
+
+func (d *DB) InsertCrash(c *CrashRow) error {
+	_, err := d.Conn.Exec(
+		`INSERT INTO crashes (id, session_id, crash_type, signal, address, registers, backtrace, java_stack_trace, exception_class, exception_message, timestamp)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		c.ID, c.SessionID, c.CrashType, c.Signal, c.Address, c.Registers, c.Backtrace, c.JavaStackTrace, c.ExceptionClass, c.ExceptionMessage, c.Timestamp,
+	)
+	if err != nil {
+		return fmt.Errorf("db.InsertCrash: %w", err)
+	}
+	return nil
+}
+
+func (d *DB) ListCrashes(sessionID string, limit, offset int) ([]CrashRow, error) {
+	rows, err := d.Conn.Query(
+		`SELECT id, session_id, crash_type, signal, address, registers, backtrace, java_stack_trace, exception_class, exception_message, timestamp
+		 FROM crashes WHERE session_id = ? ORDER BY timestamp DESC LIMIT ? OFFSET ?`,
+		sessionID, limit, offset,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("db.ListCrashes: %w", err)
+	}
+	defer rows.Close()
+	return scanCrashes(rows)
+}
+
+func (d *DB) CountCrashes(sessionID string) (int, error) {
+	var count int
+	err := d.Conn.QueryRow(`SELECT COUNT(*) FROM crashes WHERE session_id = ?`, sessionID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("db.CountCrashes: %w", err)
+	}
+	return count, nil
+}
+
+func (d *DB) SearchCrashes(sessionID string, sinceTimestamp int64, limit int) ([]CrashRow, error) {
+	query := `SELECT id, session_id, crash_type, signal, address, registers, backtrace, java_stack_trace, exception_class, exception_message, timestamp
+		 FROM crashes WHERE session_id = ?`
+	args := []any{sessionID}
+
+	if sinceTimestamp > 0 {
+		query += ` AND timestamp >= ?`
+		args = append(args, sinceTimestamp)
+	}
+
+	if limit <= 0 {
+		limit = 50
+	}
+	query += ` ORDER BY timestamp DESC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := d.Conn.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("db.SearchCrashes: %w", err)
+	}
+	defer rows.Close()
+	return scanCrashes(rows)
+}
+
+func scanCrashes(rows *sql.Rows) ([]CrashRow, error) {
+	var result []CrashRow
+	for rows.Next() {
+		var c CrashRow
+		if err := rows.Scan(
+			&c.ID, &c.SessionID, &c.CrashType, &c.Signal, &c.Address,
+			&c.Registers, &c.Backtrace, &c.JavaStackTrace,
+			&c.ExceptionClass, &c.ExceptionMessage, &c.Timestamp,
+		); err != nil {
+			return nil, err
+		}
+		result = append(result, c)
+	}
+	return result, rows.Err()
+}
+
 func (d *DB) SearchLogcatEntries(sessionID, tag, text, level string, limit int) ([]LogcatEntryRow, error) {
 	query := `SELECT id, session_id, timestamp, pid, tid, level, tag, message
 		 FROM logcat_entries WHERE session_id = ?`

--- a/internal/db/writer.go
+++ b/internal/db/writer.go
@@ -3,8 +3,9 @@ package db
 import "log/slog"
 
 type writeOp struct {
-	httpMessage  *HttpMessageRow
-	logcatEntry  *LogcatEntryRow
+	httpMessage *HttpMessageRow
+	logcatEntry *LogcatEntryRow
+	crashRow    *CrashRow
 }
 
 type AsyncWriter struct {
@@ -39,6 +40,14 @@ func (w *AsyncWriter) WriteLogcatEntry(e *LogcatEntryRow) {
 	}
 }
 
+func (w *AsyncWriter) WriteCrash(c *CrashRow) {
+	select {
+	case w.ch <- writeOp{crashRow: c}:
+	default:
+		slog.Warn("db write buffer full, dropping crash", "id", c.ID)
+	}
+}
+
 func (w *AsyncWriter) loop() {
 	defer close(w.done)
 	for op := range w.ch {
@@ -50,6 +59,11 @@ func (w *AsyncWriter) loop() {
 		if op.logcatEntry != nil {
 			if err := w.db.InsertLogcatEntry(op.logcatEntry); err != nil {
 				slog.Error("async write logcat entry", "error", err)
+			}
+		}
+		if op.crashRow != nil {
+			if err := w.db.InsertCrash(op.crashRow); err != nil {
+				slog.Error("async write crash", "error", err)
 			}
 		}
 	}

--- a/internal/features/sessions/chat/handler.go
+++ b/internal/features/sessions/chat/handler.go
@@ -137,6 +137,7 @@ func (h *Handler) Handle(c *router.Context) {
 			sessionTools = append(sessionTools,
 				chattools.NewListClasses(h.manager, sessionID),
 				chattools.NewGetClassDetail(h.manager, sessionID),
+				chattools.NewGetCrashes(h.db, sessionID),
 			)
 		}
 	}

--- a/internal/features/sessions/chat/tools/get_crashes.go
+++ b/internal/features/sessions/chat/tools/get_crashes.go
@@ -1,0 +1,100 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/joakimcarlsson/ai/agent"
+	"github.com/joakimcarlsson/ai/tool"
+	"github.com/joakimcarlsson/juicebox/internal/db"
+)
+
+type GetCrashesParams struct {
+	Since string `json:"since,omitempty" description:"ISO timestamp to filter crashes after (e.g. 2025-01-01T00:00:00Z)"`
+	Limit int    `json:"limit,omitempty" description:"Max results to return (default 50)"`
+}
+
+type GetCrashesTool struct {
+	db        *db.DB
+	sessionID string
+}
+
+func NewGetCrashes(database *db.DB, sessionID string) *GetCrashesTool {
+	return &GetCrashesTool{db: database, sessionID: sessionID}
+}
+
+func (t *GetCrashesTool) Info() tool.ToolInfo {
+	return tool.NewToolInfo(
+		"get_crashes",
+		"Get recent crash events (native signals and Java exceptions) for this session. Returns crash type, signal/exception info, stack traces, and register context. Use after running Frida scripts or launching intents to detect if the action caused a crash.",
+		GetCrashesParams{},
+	)
+}
+
+func (t *GetCrashesTool) Run(ctx context.Context, params tool.ToolCall) (tool.ToolResponse, error) {
+	input, err := agent.ParseToolInput[GetCrashesParams](params.Input)
+	if err != nil {
+		return tool.NewTextErrorResponse(fmt.Sprintf("invalid input: %v", err)), nil
+	}
+
+	var sinceTs int64
+	if input.Since != "" {
+		parsed, err := time.Parse(time.RFC3339, input.Since)
+		if err == nil {
+			sinceTs = parsed.UnixMilli()
+		}
+	}
+
+	rows, err := t.db.SearchCrashes(t.sessionID, sinceTs, input.Limit)
+	if err != nil {
+		return tool.NewTextErrorResponse(fmt.Sprintf("search failed: %v", err)), nil
+	}
+
+	if len(rows) == 0 {
+		return tool.NewTextResponse("No crash events found."), nil
+	}
+
+	type result struct {
+		ID               string            `json:"id"`
+		CrashType        string            `json:"crash_type"`
+		Signal           *string           `json:"signal,omitempty"`
+		Address          *string           `json:"address,omitempty"`
+		Registers        map[string]string `json:"registers,omitempty"`
+		Backtrace        []string          `json:"backtrace,omitempty"`
+		JavaStackTrace   *string           `json:"java_stack_trace,omitempty"`
+		ExceptionClass   *string           `json:"exception_class,omitempty"`
+		ExceptionMessage *string           `json:"exception_message,omitempty"`
+		Timestamp        int64             `json:"timestamp"`
+	}
+
+	results := make([]result, len(rows))
+	for i, r := range rows {
+		res := result{
+			ID:               r.ID,
+			CrashType:        r.CrashType,
+			Signal:           r.Signal,
+			Address:          r.Address,
+			JavaStackTrace:   r.JavaStackTrace,
+			ExceptionClass:   r.ExceptionClass,
+			ExceptionMessage: r.ExceptionMessage,
+			Timestamp:        r.Timestamp,
+		}
+		if r.Registers != nil {
+			var regs map[string]string
+			if json.Unmarshal([]byte(*r.Registers), &regs) == nil {
+				res.Registers = regs
+			}
+		}
+		if r.Backtrace != nil {
+			var bt []string
+			if json.Unmarshal([]byte(*r.Backtrace), &bt) == nil {
+				res.Backtrace = bt
+			}
+		}
+		results[i] = res
+	}
+
+	return tool.NewJSONResponse(results), nil
+}

--- a/internal/features/sessions/crashes/handler.go
+++ b/internal/features/sessions/crashes/handler.go
@@ -1,0 +1,72 @@
+package crashes
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/joakimcarlsson/go-router/router"
+	"github.com/joakimcarlsson/juicebox/internal/db"
+)
+
+type Handler struct {
+	db *db.DB
+}
+
+func NewHandler(database *db.DB) *Handler {
+	return &Handler{db: database}
+}
+
+func (h *Handler) Handle(c *router.Context) {
+	sessionId := c.Param("sessionId")
+	if sessionId == "" {
+		c.JSON(http.StatusBadRequest, map[string]string{"error": "missing sessionId"})
+		return
+	}
+
+	limit := c.QueryIntDefault("limit", 500)
+	offset := c.QueryIntDefault("offset", 0)
+
+	rows, err := h.db.ListCrashes(sessionId, limit, offset)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	total, err := h.db.CountCrashes(sessionId)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	crashes := make([]CrashResponse, 0, len(rows))
+	for _, r := range rows {
+		cr := CrashResponse{
+			ID:               r.ID,
+			CrashType:        r.CrashType,
+			Signal:           r.Signal,
+			Address:          r.Address,
+			JavaStackTrace:   r.JavaStackTrace,
+			ExceptionClass:   r.ExceptionClass,
+			ExceptionMessage: r.ExceptionMessage,
+			Timestamp:        r.Timestamp,
+		}
+		if r.Registers != nil {
+			var regs map[string]string
+			if json.Unmarshal([]byte(*r.Registers), &regs) == nil {
+				cr.Registers = regs
+			}
+		}
+		if r.Backtrace != nil {
+			var bt []string
+			if json.Unmarshal([]byte(*r.Backtrace), &bt) == nil {
+				cr.Backtrace = bt
+			}
+		}
+		crashes = append(crashes, cr)
+	}
+
+	c.JSON(http.StatusOK, CrashesResponse{
+		Crashes: crashes,
+		Total:   total,
+	})
+}

--- a/internal/features/sessions/crashes/types.go
+++ b/internal/features/sessions/crashes/types.go
@@ -1,0 +1,19 @@
+package crashes
+
+type CrashResponse struct {
+	ID               string  `json:"id"`
+	CrashType        string  `json:"crashType"`
+	Signal           *string `json:"signal"`
+	Address          *string `json:"address"`
+	Registers        any     `json:"registers"`
+	Backtrace        any     `json:"backtrace"`
+	JavaStackTrace   *string `json:"javaStackTrace"`
+	ExceptionClass   *string `json:"exceptionClass"`
+	ExceptionMessage *string `json:"exceptionMessage"`
+	Timestamp        int64   `json:"timestamp"`
+}
+
+type CrashesResponse struct {
+	Crashes []CrashResponse `json:"crashes"`
+	Total   int             `json:"total"`
+}

--- a/internal/features/sessions/routes.go
+++ b/internal/features/sessions/routes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/joakimcarlsson/juicebox/internal/features/sessions/attach"
 	"github.com/joakimcarlsson/juicebox/internal/features/sessions/chat"
 	"github.com/joakimcarlsson/juicebox/internal/features/sessions/classes"
+	"github.com/joakimcarlsson/juicebox/internal/features/sessions/crashes"
 	"github.com/joakimcarlsson/juicebox/internal/features/sessions/detach"
 	"github.com/joakimcarlsson/juicebox/internal/features/sessions/filesystem"
 	"github.com/joakimcarlsson/juicebox/internal/features/sessions/intercept"
@@ -30,6 +31,7 @@ func RegisterRoutes(r *router.Router, manager *session.Manager, database *db.DB,
 	interceptHandler := intercept.NewHandler(manager)
 	fsHandler := filesystem.NewHandler(manager)
 	classesHandler := classes.NewHandler(manager)
+	crashesHandler := crashes.NewHandler(database)
 
 	r.POST("/devices/{deviceId}/apps/{bundleId}/attach", attachHandler.Handle)
 	r.DELETE("/sessions/{sessionId}", detachHandler.Handle)
@@ -53,6 +55,8 @@ func RegisterRoutes(r *router.Router, manager *session.Manager, database *db.DB,
 	r.GET("/sessions/{sessionId}/sqlite/tables", sqliteHandler.Tables)
 	r.POST("/sessions/{sessionId}/sqlite/query", sqliteHandler.Query)
 	r.GET("/sessions/{sessionId}/sqlite/export", sqliteHandler.Export)
+
+	r.GET("/sessions/{sessionId}/crashes", crashesHandler.Handle)
 
 	r.GET("/sessions/{sessionId}/classes", classesHandler.List)
 	r.GET("/sessions/{sessionId}/classes/detail", classesHandler.Detail)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -302,6 +302,51 @@ func (m *Manager) bridgeSubscribeForward(sess *Session) {
 			continue
 		}
 		hub.Broadcast(data)
+
+		if msg.Type == "crash" {
+			var crash struct {
+				ID               string            `json:"id"`
+				CrashType        string            `json:"crashType"`
+				Signal           *string           `json:"signal"`
+				Address          *string           `json:"address"`
+				Registers        map[string]string `json:"registers"`
+				Backtrace        []string          `json:"backtrace"`
+				JavaStackTrace   *string           `json:"javaStackTrace"`
+				ExceptionClass   *string           `json:"exceptionClass"`
+				ExceptionMessage *string           `json:"exceptionMessage"`
+				Timestamp        int64             `json:"timestamp"`
+			}
+			if err := json.Unmarshal(msg.Payload, &crash); err == nil && crash.ID != "" {
+				var regsJSON *string
+				if crash.Registers != nil {
+					b, _ := json.Marshal(crash.Registers)
+					s := string(b)
+					regsJSON = &s
+				}
+				var btJSON *string
+				if crash.Backtrace != nil {
+					b, _ := json.Marshal(crash.Backtrace)
+					s := string(b)
+					btJSON = &s
+				}
+				if crash.Timestamp == 0 {
+					crash.Timestamp = time.Now().UnixMilli()
+				}
+				m.writer.WriteCrash(&db.CrashRow{
+					ID:               crash.ID,
+					SessionID:        sess.ID,
+					CrashType:        crash.CrashType,
+					Signal:           crash.Signal,
+					Address:          crash.Address,
+					Registers:        regsJSON,
+					Backtrace:        btJSON,
+					JavaStackTrace:   crash.JavaStackTrace,
+					ExceptionClass:   crash.ExceptionClass,
+					ExceptionMessage: crash.ExceptionMessage,
+					Timestamp:        crash.Timestamp,
+				})
+			}
+		}
 	}
 }
 

--- a/sidecar/bridge.ts
+++ b/sidecar/bridge.ts
@@ -342,6 +342,24 @@ async function handleAttach(
     }
   }
 
+  try {
+    await script.exports.invoke("crash", "enable", []);
+  } catch (err) {
+    const description = err instanceof Error ? err.message : String(err);
+    console.error(`[${sessionId}] crash handler setup failed:`, err);
+    const errLine = JSON.stringify({ type: "log", payload: { level: "error", source: "agent", message: `crash handler setup failed: ${description}` } }) + "\n";
+    if (state.subscribers.size === 0) {
+      state.messageBuffer.push(errLine);
+    } else {
+      const errEncoded = new TextEncoder().encode(errLine);
+      for (const sub of state.subscribers) {
+        sub.write(errEncoded).catch(() => {
+          state.subscribers.delete(sub);
+        });
+      }
+    }
+  }
+
   await device.resume(pid);
   console.log(`attached to ${identifier} (pid ${pid}), session ${sessionId}`);
 

--- a/web/src/components/sessions/CrashAlertDialog.tsx
+++ b/web/src/components/sessions/CrashAlertDialog.tsx
@@ -1,0 +1,212 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useNavigate } from "@tanstack/react-router"
+import { AlertTriangle, RotateCcw, ArrowRight, Cpu, Coffee, Skull } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { useDeviceSocket } from "@/contexts/DeviceSocketContext"
+import { attachApp } from "@/features/sessions/api"
+import type { CrashEvent, DeviceEnvelope } from "@/types/session"
+import { cn } from "@/lib/utils"
+
+interface CrashAlertDialogProps {
+  sessionId: string
+  deviceId: string
+  bundleId: string
+}
+
+type AlertState =
+  | { kind: "closed" }
+  | { kind: "crash"; crash: CrashEvent; detached: boolean }
+  | { kind: "detached" }
+
+export function CrashAlertDialog({ sessionId, deviceId, bundleId }: CrashAlertDialogProps) {
+  const { subscribe } = useDeviceSocket()
+  const navigate = useNavigate()
+  const [state, setState] = useState<AlertState>({ kind: "closed" })
+  const [reattaching, setReattaching] = useState(false)
+  const lastCrashTime = useRef(0)
+
+  useEffect(() => {
+    if (!sessionId) return
+
+    const unsub = subscribe(null, (envelope: DeviceEnvelope) => {
+      if (envelope.sessionId !== sessionId) return
+
+      if (envelope.type === "crash") {
+        const crash = envelope.payload as CrashEvent
+        lastCrashTime.current = Date.now()
+        setState({ kind: "crash", crash, detached: false })
+      }
+
+      if (envelope.type === "detached") {
+        const recentCrash = Date.now() - lastCrashTime.current < 5000
+        setState((prev) => {
+          if (prev.kind === "crash") {
+            return { ...prev, detached: true }
+          }
+          if (!recentCrash) {
+            return { kind: "detached" }
+          }
+          return prev
+        })
+      }
+    })
+
+    return unsub
+  }, [subscribe, sessionId])
+
+  const handleReattach = useCallback(async () => {
+    setReattaching(true)
+    try {
+      const resp = await attachApp(deviceId, bundleId, sessionId)
+      setState({ kind: "closed" })
+      navigate({
+        to: "/devices/$deviceId/app/$bundleId/home",
+        params: { deviceId, bundleId },
+        search: { sessionId: resp.sessionId },
+        replace: true,
+      })
+    } catch {
+      setReattaching(false)
+    }
+  }, [deviceId, bundleId, sessionId, navigate])
+
+  const handleViewCrashes = useCallback(() => {
+    setState({ kind: "closed" })
+    navigate({
+      to: "/devices/$deviceId/app/$bundleId/crashes",
+      params: { deviceId, bundleId },
+      search: { sessionId },
+    })
+  }, [deviceId, bundleId, sessionId, navigate])
+
+  const handleDismiss = useCallback(() => {
+    setState({ kind: "closed" })
+    setReattaching(false)
+  }, [])
+
+  if (state.kind === "closed") return null
+
+  const showReattach = state.kind === "detached" || (state.kind === "crash" && state.detached)
+  const crash = state.kind === "crash" ? state.crash : null
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) handleDismiss() }}>
+      <DialogContent showCloseButton={!reattaching} className="sm:max-w-md">
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <div className={cn(
+              "flex h-10 w-10 items-center justify-center rounded-full",
+              crash ? "bg-red-500/10" : "bg-amber-500/10",
+            )}>
+              {crash ? (
+                <Skull className="h-5 w-5 text-red-500" />
+              ) : (
+                <AlertTriangle className="h-5 w-5 text-amber-500" />
+              )}
+            </div>
+            <div>
+              <DialogTitle>
+                {crash ? "App Crashed" : "Session Lost"}
+              </DialogTitle>
+              <DialogDescription>
+                {crash
+                  ? "The target app encountered a fatal error"
+                  : "The connection to the target app was lost"}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        {crash && (
+          <div className="rounded-md border border-red-500/20 bg-red-500/5 p-3 space-y-2">
+            <div className="flex items-center gap-2">
+              <Badge
+                variant={crash.crashType === "native" ? "destructive" : "secondary"}
+                className="text-[10px] px-1.5 py-0"
+              >
+                {crash.crashType === "native" ? (
+                  <Cpu className="mr-1 h-2.5 w-2.5" />
+                ) : (
+                  <Coffee className="mr-1 h-2.5 w-2.5" />
+                )}
+                {crash.crashType === "native" ? "NATIVE" : "JAVA"}
+              </Badge>
+              {crash.signal && (
+                <Badge variant="outline" className="text-[10px] px-1.5 py-0 font-mono border-red-500/30 text-red-600 dark:text-red-400">
+                  {crash.signal}
+                </Badge>
+              )}
+              {crash.exceptionClass && (
+                <span className="text-xs font-mono text-red-600 dark:text-red-400 truncate">
+                  {crash.exceptionClass}
+                </span>
+              )}
+            </div>
+
+            {crash.exceptionMessage && (
+              <p className="text-xs text-red-700 dark:text-red-300 font-mono break-all line-clamp-2">
+                {crash.exceptionMessage}
+              </p>
+            )}
+
+            {crash.crashType === "native" && crash.backtrace && crash.backtrace.length > 0 && (
+              <div className="text-[11px] font-mono text-muted-foreground space-y-0.5">
+                {crash.backtrace.slice(0, 3).map((frame, i) => (
+                  <div key={i} className="truncate">
+                    <span className="text-muted-foreground/60">#{i}</span> {frame}
+                  </div>
+                ))}
+                {crash.backtrace.length > 3 && (
+                  <div className="text-muted-foreground/60">
+                    ... {crash.backtrace.length - 3} more frames
+                  </div>
+                )}
+              </div>
+            )}
+
+            {crash.crashType === "java" && crash.javaStackTrace && (
+              <pre className="text-[11px] font-mono text-muted-foreground whitespace-pre-wrap break-all line-clamp-4 leading-4">
+                {crash.javaStackTrace}
+              </pre>
+            )}
+          </div>
+        )}
+
+        {showReattach && (
+          <p className="text-xs text-muted-foreground">
+            The app process has terminated. You can reattach to restore the session with all its history.
+          </p>
+        )}
+
+        <DialogFooter>
+          {crash && (
+            <Button variant="outline" size="sm" onClick={handleViewCrashes} disabled={reattaching}>
+              <ArrowRight className="mr-1.5 h-3.5 w-3.5" />
+              View in Crashes
+            </Button>
+          )}
+          {showReattach && (
+            <Button size="sm" onClick={handleReattach} disabled={reattaching}>
+              <RotateCcw className={cn("mr-1.5 h-3.5 w-3.5", reattaching && "animate-spin")} />
+              {reattaching ? "Reattaching..." : "Reattach"}
+            </Button>
+          )}
+          {!showReattach && (
+            <Button variant="outline" size="sm" onClick={handleDismiss}>
+              Dismiss
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/contexts/SessionMessageContext.tsx
+++ b/web/src/contexts/SessionMessageContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useRef, useState } from "react"
 import { useDeviceSocket } from "@/contexts/DeviceSocketContext"
 import type { AgentMessage, DeviceEnvelope } from "@/types/session"
-import { fetchSessionMessages, fetchSessionLogs } from "@/features/sessions/api"
+import { fetchSessionMessages, fetchSessionLogs, fetchSessionCrashes } from "@/features/sessions/api"
 
 interface SessionMessageContextValue {
   messages: AgentMessage[]
@@ -52,7 +52,8 @@ export function SessionMessageProvider({
     Promise.all([
       fetchSessionMessages(sessionId).catch(() => null),
       fetchSessionLogs(sessionId).catch(() => null),
-    ]).then(([msgResp, logResp]) => {
+      fetchSessionCrashes(sessionId).catch(() => null),
+    ]).then(([msgResp, logResp, crashResp]) => {
       const historical: AgentMessage[] = []
 
       if (msgResp?.messages) {
@@ -69,6 +70,15 @@ export function SessionMessageProvider({
           if (!seenIds.current.has(e.id)) {
             seenIds.current.add(e.id)
             historical.push({ type: "logcat", payload: e })
+          }
+        }
+      }
+
+      if (crashResp?.crashes) {
+        for (const c of crashResp.crashes) {
+          if (!seenIds.current.has(c.id)) {
+            seenIds.current.add(c.id)
+            historical.push({ type: "crash", payload: c })
           }
         }
       }

--- a/web/src/features/sessions/api.ts
+++ b/web/src/features/sessions/api.ts
@@ -1,4 +1,4 @@
-import type { AttachResponse, SessionsResponse, MessagesResponse, LogsResponse, InterceptState, InterceptDecision, InterceptRule, PendingRequest } from "@/types/session"
+import type { AttachResponse, SessionsResponse, MessagesResponse, LogsResponse, CrashesResponse, InterceptState, InterceptDecision, InterceptRule, PendingRequest } from "@/types/session"
 
 export async function attachApp(
   deviceId: string,
@@ -87,6 +87,18 @@ export async function fetchSessionLogs(
     `/api/v1/sessions/${sessionId}/logs?limit=${limit}&offset=${offset}`,
   )
   if (!res.ok) throw new Error("Failed to fetch logs")
+  return res.json()
+}
+
+export async function fetchSessionCrashes(
+  sessionId: string,
+  limit = 500,
+  offset = 0,
+): Promise<CrashesResponse> {
+  const res = await fetch(
+    `/api/v1/sessions/${sessionId}/crashes?limit=${limit}&offset=${offset}`,
+  )
+  if (!res.ok) throw new Error("Failed to fetch crashes")
   return res.json()
 }
 

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as DevicesDeviceIdAppBundleIdNetworkRouteImport } from './routes/
 import { Route as DevicesDeviceIdAppBundleIdLogsRouteImport } from './routes/devices/$deviceId/app/$bundleId/logs'
 import { Route as DevicesDeviceIdAppBundleIdHomeRouteImport } from './routes/devices/$deviceId/app/$bundleId/home'
 import { Route as DevicesDeviceIdAppBundleIdFilesRouteImport } from './routes/devices/$deviceId/app/$bundleId/files'
+import { Route as DevicesDeviceIdAppBundleIdCrashesRouteImport } from './routes/devices/$deviceId/app/$bundleId/crashes'
 import { Route as DevicesDeviceIdAppBundleIdClassesRouteImport } from './routes/devices/$deviceId/app/$bundleId/classes'
 
 const IndexRoute = IndexRouteImport.update({
@@ -84,6 +85,12 @@ const DevicesDeviceIdAppBundleIdFilesRoute =
     path: '/files',
     getParentRoute: () => DevicesDeviceIdAppBundleIdRoute,
   } as any)
+const DevicesDeviceIdAppBundleIdCrashesRoute =
+  DevicesDeviceIdAppBundleIdCrashesRouteImport.update({
+    id: '/crashes',
+    path: '/crashes',
+    getParentRoute: () => DevicesDeviceIdAppBundleIdRoute,
+  } as any)
 const DevicesDeviceIdAppBundleIdClassesRoute =
   DevicesDeviceIdAppBundleIdClassesRouteImport.update({
     id: '/classes',
@@ -99,6 +106,7 @@ export interface FileRoutesByFullPath {
   '/devices/$deviceId/': typeof DevicesDeviceIdIndexRoute
   '/devices/$deviceId/app/$bundleId': typeof DevicesDeviceIdAppBundleIdRouteWithChildren
   '/devices/$deviceId/app/$bundleId/classes': typeof DevicesDeviceIdAppBundleIdClassesRoute
+  '/devices/$deviceId/app/$bundleId/crashes': typeof DevicesDeviceIdAppBundleIdCrashesRoute
   '/devices/$deviceId/app/$bundleId/files': typeof DevicesDeviceIdAppBundleIdFilesRoute
   '/devices/$deviceId/app/$bundleId/home': typeof DevicesDeviceIdAppBundleIdHomeRoute
   '/devices/$deviceId/app/$bundleId/logs': typeof DevicesDeviceIdAppBundleIdLogsRoute
@@ -111,6 +119,7 @@ export interface FileRoutesByTo {
   '/devices/$deviceId/processes': typeof DevicesDeviceIdProcessesRoute
   '/devices/$deviceId': typeof DevicesDeviceIdIndexRoute
   '/devices/$deviceId/app/$bundleId/classes': typeof DevicesDeviceIdAppBundleIdClassesRoute
+  '/devices/$deviceId/app/$bundleId/crashes': typeof DevicesDeviceIdAppBundleIdCrashesRoute
   '/devices/$deviceId/app/$bundleId/files': typeof DevicesDeviceIdAppBundleIdFilesRoute
   '/devices/$deviceId/app/$bundleId/home': typeof DevicesDeviceIdAppBundleIdHomeRoute
   '/devices/$deviceId/app/$bundleId/logs': typeof DevicesDeviceIdAppBundleIdLogsRoute
@@ -126,6 +135,7 @@ export interface FileRoutesById {
   '/devices/$deviceId/': typeof DevicesDeviceIdIndexRoute
   '/devices/$deviceId/app/$bundleId': typeof DevicesDeviceIdAppBundleIdRouteWithChildren
   '/devices/$deviceId/app/$bundleId/classes': typeof DevicesDeviceIdAppBundleIdClassesRoute
+  '/devices/$deviceId/app/$bundleId/crashes': typeof DevicesDeviceIdAppBundleIdCrashesRoute
   '/devices/$deviceId/app/$bundleId/files': typeof DevicesDeviceIdAppBundleIdFilesRoute
   '/devices/$deviceId/app/$bundleId/home': typeof DevicesDeviceIdAppBundleIdHomeRoute
   '/devices/$deviceId/app/$bundleId/logs': typeof DevicesDeviceIdAppBundleIdLogsRoute
@@ -142,6 +152,7 @@ export interface FileRouteTypes {
     | '/devices/$deviceId/'
     | '/devices/$deviceId/app/$bundleId'
     | '/devices/$deviceId/app/$bundleId/classes'
+    | '/devices/$deviceId/app/$bundleId/crashes'
     | '/devices/$deviceId/app/$bundleId/files'
     | '/devices/$deviceId/app/$bundleId/home'
     | '/devices/$deviceId/app/$bundleId/logs'
@@ -154,6 +165,7 @@ export interface FileRouteTypes {
     | '/devices/$deviceId/processes'
     | '/devices/$deviceId'
     | '/devices/$deviceId/app/$bundleId/classes'
+    | '/devices/$deviceId/app/$bundleId/crashes'
     | '/devices/$deviceId/app/$bundleId/files'
     | '/devices/$deviceId/app/$bundleId/home'
     | '/devices/$deviceId/app/$bundleId/logs'
@@ -168,6 +180,7 @@ export interface FileRouteTypes {
     | '/devices/$deviceId/'
     | '/devices/$deviceId/app/$bundleId'
     | '/devices/$deviceId/app/$bundleId/classes'
+    | '/devices/$deviceId/app/$bundleId/crashes'
     | '/devices/$deviceId/app/$bundleId/files'
     | '/devices/$deviceId/app/$bundleId/home'
     | '/devices/$deviceId/app/$bundleId/logs'
@@ -259,6 +272,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DevicesDeviceIdAppBundleIdFilesRouteImport
       parentRoute: typeof DevicesDeviceIdAppBundleIdRoute
     }
+    '/devices/$deviceId/app/$bundleId/crashes': {
+      id: '/devices/$deviceId/app/$bundleId/crashes'
+      path: '/crashes'
+      fullPath: '/devices/$deviceId/app/$bundleId/crashes'
+      preLoaderRoute: typeof DevicesDeviceIdAppBundleIdCrashesRouteImport
+      parentRoute: typeof DevicesDeviceIdAppBundleIdRoute
+    }
     '/devices/$deviceId/app/$bundleId/classes': {
       id: '/devices/$deviceId/app/$bundleId/classes'
       path: '/classes'
@@ -271,6 +291,7 @@ declare module '@tanstack/react-router' {
 
 interface DevicesDeviceIdAppBundleIdRouteChildren {
   DevicesDeviceIdAppBundleIdClassesRoute: typeof DevicesDeviceIdAppBundleIdClassesRoute
+  DevicesDeviceIdAppBundleIdCrashesRoute: typeof DevicesDeviceIdAppBundleIdCrashesRoute
   DevicesDeviceIdAppBundleIdFilesRoute: typeof DevicesDeviceIdAppBundleIdFilesRoute
   DevicesDeviceIdAppBundleIdHomeRoute: typeof DevicesDeviceIdAppBundleIdHomeRoute
   DevicesDeviceIdAppBundleIdLogsRoute: typeof DevicesDeviceIdAppBundleIdLogsRoute
@@ -282,6 +303,8 @@ const DevicesDeviceIdAppBundleIdRouteChildren: DevicesDeviceIdAppBundleIdRouteCh
   {
     DevicesDeviceIdAppBundleIdClassesRoute:
       DevicesDeviceIdAppBundleIdClassesRoute,
+    DevicesDeviceIdAppBundleIdCrashesRoute:
+      DevicesDeviceIdAppBundleIdCrashesRoute,
     DevicesDeviceIdAppBundleIdFilesRoute: DevicesDeviceIdAppBundleIdFilesRoute,
     DevicesDeviceIdAppBundleIdHomeRoute: DevicesDeviceIdAppBundleIdHomeRoute,
     DevicesDeviceIdAppBundleIdLogsRoute: DevicesDeviceIdAppBundleIdLogsRoute,

--- a/web/src/routes/devices/$deviceId/app/$bundleId.tsx
+++ b/web/src/routes/devices/$deviceId/app/$bundleId.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { SessionStatusReporter } from "@/components/layout/SessionStatusReporter"
+import { CrashAlertDialog } from "@/components/sessions/CrashAlertDialog"
 import { SessionMessageProvider } from "@/contexts/SessionMessageContext"
 import { InterceptProvider } from "@/contexts/InterceptContext"
 import { ChatPanelProvider, useChatPanel } from "@/contexts/ChatPanelContext"
@@ -22,7 +23,7 @@ import {
   ResizableHandle,
 } from "@/components/ui/resizable"
 import { useDefaultLayout } from "react-resizable-panels"
-import { ArrowLeft, Home, Globe, FileText, Code, Terminal, MessageSquare, FolderOpen, Blocks } from "lucide-react"
+import { ArrowLeft, Home, Globe, FileText, Code, Terminal, MessageSquare, FolderOpen, Blocks, AlertTriangle } from "lucide-react"
 import { useEffect, useRef, useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { appSessionsQueryOptions } from "@/features/sessions/queries"
@@ -45,6 +46,7 @@ function getTabs(capabilities: string[] | null) {
     { value: "logs", label: "Logs", icon: FileText, enabled: has("logstream"), to: "/devices/$deviceId/app/$bundleId/logs" as const },
     { value: "files", label: "Files", icon: FolderOpen, enabled: has("filesystem"), to: "/devices/$deviceId/app/$bundleId/files" as const },
     { value: "classes", label: "Classes", icon: Blocks, enabled: has("frida"), to: "/devices/$deviceId/app/$bundleId/classes" as const },
+    { value: "crashes", label: "Crashes", icon: AlertTriangle, enabled: has("frida"), to: "/devices/$deviceId/app/$bundleId/crashes" as const },
     { value: "hooks", label: "Hooks", icon: Code, enabled: false, to: "/devices/$deviceId/app/$bundleId/network" as const },
   ]
 }
@@ -121,6 +123,7 @@ function AppLayoutWithChat({
   return (
     <div className="flex h-full flex-col">
       {sessionId && <SessionStatusReporter sessionId={sessionId} bundleId={bundleId} />}
+      {sessionId && <CrashAlertDialog sessionId={sessionId} deviceId={deviceId} bundleId={bundleId} />}
 
       <div className="border-b border-border px-4 py-2">
         <div className="flex items-center justify-between">

--- a/web/src/routes/devices/$deviceId/app/$bundleId/crashes.tsx
+++ b/web/src/routes/devices/$deviceId/app/$bundleId/crashes.tsx
@@ -1,0 +1,250 @@
+import { createFileRoute, useSearch } from "@tanstack/react-router"
+import { useCallback, useMemo, useState } from "react"
+import { AlertTriangle, Download, ChevronDown, ChevronRight, Cpu, Coffee, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { useSessionMessages } from "@/contexts/SessionMessageContext"
+import type { CrashEvent } from "@/types/session"
+import { cn } from "@/lib/utils"
+import { NoSessionEmptyState } from "@/components/sessions/NoSessionEmptyState"
+
+export const Route = createFileRoute(
+  "/devices/$deviceId/app/$bundleId/crashes",
+)({
+  validateSearch: (search: Record<string, unknown>) => ({
+    sessionId: (search.sessionId as string) ?? "",
+  }),
+  component: CrashesPage,
+})
+
+function formatTimestamp(ts: number): string {
+  return new Date(ts).toLocaleString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    fractionalSecondDigits: 3,
+    month: "short",
+    day: "numeric",
+  })
+}
+
+function CrashesPage() {
+  const { sessionId } = useSearch({
+    from: "/devices/$deviceId/app/$bundleId/crashes",
+  })
+  const { messages } = useSessionMessages()
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [clearIndex, setClearIndex] = useState(0)
+
+  const clear = useCallback(() => setClearIndex(messages.length), [messages.length])
+
+  const crashes = useMemo(() => {
+    return messages
+      .slice(clearIndex)
+      .filter(
+        (m): m is { type: "crash"; payload: CrashEvent } =>
+          m.type === "crash" && !!m.payload,
+      )
+      .map((m) => m.payload as unknown as CrashEvent)
+      .reverse()
+  }, [messages, clearIndex])
+
+  const exportCrashes = useCallback(() => {
+    const data = JSON.stringify(crashes, null, 2)
+    const blob = new Blob([data], { type: "application/json" })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = `crashes-${sessionId}-${Date.now()}.json`
+    a.click()
+    URL.revokeObjectURL(url)
+  }, [crashes, sessionId])
+
+  const exportSingle = useCallback((crash: CrashEvent) => {
+    const data = JSON.stringify(crash, null, 2)
+    const blob = new Blob([data], { type: "application/json" })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = `crash-${crash.id}.json`
+    a.click()
+    URL.revokeObjectURL(url)
+  }, [])
+
+  if (!sessionId) {
+    return <NoSessionEmptyState />
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2 border-b border-border px-4 py-2">
+        <span className="text-xs text-muted-foreground">
+          {crashes.length} crash{crashes.length !== 1 ? "es" : ""}
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          <Button variant="ghost" size="sm" className="h-8" onClick={clear}>
+            <Trash2 className="mr-1.5 h-3 w-3" />
+            Clear
+          </Button>
+          {crashes.length > 0 && (
+            <Button variant="ghost" size="sm" className="h-8" onClick={exportCrashes}>
+              <Download className="mr-1.5 h-3 w-3" />
+              Export All
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-auto">
+        {crashes.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 h-full text-muted-foreground">
+            <AlertTriangle className="h-8 w-8 opacity-30" />
+            <p className="text-sm">No crashes detected yet</p>
+            <p className="text-xs opacity-60">
+              Native signals and Java exceptions will appear here
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y divide-border">
+            {crashes.map((crash) => {
+              const isExpanded = expandedId === crash.id
+              const isNative = crash.crashType === "native"
+              return (
+                <div key={crash.id} className="group">
+                  <button
+                    onClick={() => setExpandedId(isExpanded ? null : crash.id)}
+                    className={cn(
+                      "w-full text-left px-4 py-3 flex items-start gap-3 hover:bg-muted/50 transition-colors",
+                      isExpanded && "bg-muted/30",
+                    )}
+                  >
+                    <div className="mt-0.5">
+                      {isExpanded ? (
+                        <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                      ) : (
+                        <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+                      )}
+                    </div>
+
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <Badge
+                          variant={isNative ? "destructive" : "secondary"}
+                          className="text-[10px] px-1.5 py-0"
+                        >
+                          {isNative ? (
+                            <Cpu className="mr-1 h-2.5 w-2.5" />
+                          ) : (
+                            <Coffee className="mr-1 h-2.5 w-2.5" />
+                          )}
+                          {isNative ? "NATIVE" : "JAVA"}
+                        </Badge>
+                        {crash.signal && (
+                          <Badge variant="outline" className="text-[10px] px-1.5 py-0 font-mono text-red-600 dark:text-red-400">
+                            {crash.signal}
+                          </Badge>
+                        )}
+                        {crash.exceptionClass && (
+                          <span className="text-xs font-mono text-red-600 dark:text-red-400 truncate">
+                            {crash.exceptionClass}
+                          </span>
+                        )}
+                        <span className="text-[10px] text-muted-foreground ml-auto shrink-0">
+                          {formatTimestamp(crash.timestamp)}
+                        </span>
+                      </div>
+
+                      <p className="text-xs text-muted-foreground truncate font-mono">
+                        {isNative
+                          ? crash.backtrace?.[0] ?? `Crash at ${crash.address ?? "unknown"}`
+                          : crash.exceptionMessage ?? "Uncaught exception"}
+                      </p>
+                    </div>
+                  </button>
+
+                  {isExpanded && (
+                    <CrashDetail crash={crash} onExport={exportSingle} />
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function CrashDetail({
+  crash,
+  onExport,
+}: {
+  crash: CrashEvent
+  onExport: (crash: CrashEvent) => void
+}) {
+  const isNative = crash.crashType === "native"
+
+  return (
+    <div className="px-4 pb-4 pl-11 space-y-3">
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" className="h-7 text-xs" onClick={() => onExport(crash)}>
+          <Download className="mr-1.5 h-3 w-3" />
+          Export
+        </Button>
+      </div>
+
+      {isNative && crash.address && (
+        <DetailSection title="Crash Address">
+          <code className="text-xs font-mono text-red-600 dark:text-red-400">{crash.address}</code>
+        </DetailSection>
+      )}
+
+      {isNative && crash.registers && Object.keys(crash.registers).length > 0 && (
+        <DetailSection title="Registers">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-x-4 gap-y-1">
+            {Object.entries(crash.registers).map(([reg, val]) => (
+              <div key={reg} className="flex items-baseline gap-2 font-mono text-xs">
+                <span className="text-muted-foreground w-8 text-right shrink-0">{reg}</span>
+                <span className="text-foreground truncate">{val}</span>
+              </div>
+            ))}
+          </div>
+        </DetailSection>
+      )}
+
+      {isNative && crash.backtrace && crash.backtrace.length > 0 && (
+        <DetailSection title="Native Backtrace">
+          <div className="space-y-0.5">
+            {crash.backtrace.map((frame, i) => (
+              <div key={i} className="flex gap-2 font-mono text-xs">
+                <span className="text-muted-foreground w-6 text-right shrink-0">#{i}</span>
+                <span className="text-foreground break-all">{frame}</span>
+              </div>
+            ))}
+          </div>
+        </DetailSection>
+      )}
+
+      {!isNative && crash.javaStackTrace && (
+        <DetailSection title="Java Stack Trace">
+          <pre className="text-xs font-mono whitespace-pre-wrap break-all text-foreground leading-5">
+            {crash.javaStackTrace}
+          </pre>
+        </DetailSection>
+      )}
+    </div>
+  )
+}
+
+function DetailSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <h4 className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground mb-1.5">
+        {title}
+      </h4>
+      <div className="rounded-md border border-border bg-muted/30 p-3">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/web/src/types/session.ts
+++ b/web/src/types/session.ts
@@ -77,6 +77,24 @@ export interface LogsResponse {
   total: number
 }
 
+export interface CrashEvent {
+  id: string
+  crashType: "native" | "java"
+  signal: string | null
+  address: string | null
+  registers: Record<string, string> | null
+  backtrace: string[]
+  javaStackTrace: string | null
+  exceptionClass: string | null
+  exceptionMessage: string | null
+  timestamp: number
+}
+
+export interface CrashesResponse {
+  crashes: CrashEvent[]
+  total: number
+}
+
 export interface InterceptRule {
   id: string
   enabled: boolean


### PR DESCRIPTION
This pull request introduces comprehensive crash detection, recording, and retrieval capabilities for both native and Java crashes in the system. It adds a Frida agent module to capture crash events, extends the backend to store and query crash data, and exposes new API and chat tool endpoints to access crash information per session.

closes #15 