### PR TITLE
feat: enhance frida-server management and add VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "deno.enablePaths": ["sidecar"],
+  "deno.lint": true,
+  "deno.unstable": true
+}

--- a/sidecar/src/frida-server.ts
+++ b/sidecar/src/frida-server.ts
@@ -1,3 +1,4 @@
+import frida from "frida";
 import { resolve } from "node:path";
 import { exec } from "./utils.ts";
 
@@ -35,8 +36,27 @@ export async function isFridaServerRunning(deviceId: string): Promise<boolean> {
   return stdout.includes("frida-server");
 }
 
+async function waitForFridaReady(
+  deviceId: string,
+  maxAttempts = 10,
+): Promise<void> {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const d = await frida.getDevice(deviceId);
+      await d.enumerateProcesses();
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+  throw new Error("frida-server not accepting connections");
+}
+
 export async function ensureFridaServer(deviceId: string): Promise<void> {
-  if (await isFridaServerRunning(deviceId)) return;
+  if (await isFridaServerRunning(deviceId)) {
+    await waitForFridaReady(deviceId);
+    return;
+  }
 
   console.log(`frida-server not running on ${deviceId}, installing...`);
 
@@ -115,12 +135,6 @@ export async function ensureFridaServer(deviceId: string): Promise<void> {
     stderr: "null",
   }).spawn();
 
-  for (let i = 0; i < 10; i++) {
-    await new Promise((r) => setTimeout(r, 500));
-    if (await isFridaServerRunning(deviceId)) {
-      console.log("frida-server is running");
-      return;
-    }
-  }
-  throw new Error("frida-server failed to start");
+  await waitForFridaReady(deviceId, 20);
+  console.log("frida-server is running and accepting connections");
 }

--- a/sidecar/src/methods/session.ts
+++ b/sidecar/src/methods/session.ts
@@ -31,7 +31,20 @@ export async function handleAttach(
 
   const device = await frida.getDevice(deviceId);
 
-  const pid = await device.spawn(identifier);
+  let pid!: number;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      pid = await device.spawn(identifier);
+      break;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("Need Gadget") && attempt < 2) {
+        await new Promise((r) => setTimeout(r, 1000));
+        continue;
+      }
+      throw err;
+    }
+  }
   const session = await device.attach(pid);
   const agentSource = await Deno.readTextFile(AGENT_PATH);
   const script = await session.createScript(agentSource);


### PR DESCRIPTION
Closes #59 

- Introduced a new VSCode settings file to configure Deno environment.
- Added a `waitForFridaReady` function to improve frida-server readiness checks.
- Updated `ensureFridaServer` to utilize the new readiness function.
- Enhanced error handling in `handleAttach` for spawning processes with retries.
- Streamlined route definitions in `routeTree.gen.ts` for better readability.